### PR TITLE
NCSD-1892: Service bus topics + subscriptions

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -87,11 +87,10 @@
         "webAppInsightsName": "[concat(variables('webAppName'), '-ai')]",
         "functionAppName": "[concat(variables('ResourcePrefix'), '-fa')]",
         "functionAppInsightsName": "[concat(variables('functionAppName'), '-ai')]",
-        "mainTopicName": "job-profile-profile-topic",
-        "postSubscriptionName": "job-profile-post",
-        "patchSubscriptionName": "job-profile-patch",
-        "deleteTopicName": "job-profile-delete-topic",
-        "deleteSubscriptionName": "job-profile-delete"
+        "cmsTopicName": "cms-messages",
+        "cmsSubscriptionName": "job-profile-metadata",
+        "refreshTopicName": "job-profile-refresh",
+        "refreshSubscriptionName": "job-profile-segment-refresh"
     },
     "resources": [
         {
@@ -229,7 +228,7 @@
                             },
                             {
                                 "name": "OverviewBannerSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "OverviewBannerSegmentClientOptions__BaseAddress",
@@ -245,7 +244,7 @@
                             },
                             {
                                 "name": "CurrentOpportunitiesSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "CurrentOpportunitiesSegmentClientOptions__BaseAddress",
@@ -261,7 +260,7 @@
                             },
                             {
                                 "name": "CareerPathSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "CareerPathSegmentClientOptions__BaseAddress",
@@ -277,7 +276,7 @@
                             },
                             {
                                 "name": "HowToBecomeSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "HowToBecomeSegmentClientOptions__BaseAddress",
@@ -293,7 +292,7 @@
                             },
                             {
                                 "name": "RelatedCareersSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "RelatedCareersSegmentClientOptions__BaseAddress",
@@ -309,7 +308,7 @@
                             },
                             {
                                 "name": "WhatItTakesSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "WhatItTakesSegmentClientOptions__BaseAddress",
@@ -325,7 +324,7 @@
                             },
                             {
                                 "name": "WhatYouWillDoSegmentClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "WhatYouWillDoSegmentClientOptions__BaseAddress",
@@ -416,32 +415,24 @@
                                 "value": "[listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.ServiceBus/namespaces/authorizationRules', parameters('appSharedServiceBusName'), 'ReadWrite'), '2017-04-01').primaryConnectionString]"
                             },
                             {
-                                "name": "Values__patch-profile-topic-name",
-                                "value": "job-profile-profile-topic"
+                                "name": "Values__cms-messages-topic",
+                                "value": "[variables('cmsTopicName')]"
                             },
                             {
-                                "name": "Values__patch-profile-subscription-name",
-                                "value": "job-profile-patch"
+                                "name": "Values__cms-messages-subscription",
+                                "value": "[variables('cmsSubscriptionName')]"
                             },
                             {
-                                "name": "Values__post-profile-topic-name",
-                                "value": "job-profile-profile-topic"
+                                "name": "Values__job-profiles-refresh-topic",
+                                "value": "[variables('refreshTopicName')]"
                             },
                             {
-                                "name": "Values__post-profile-subscription-name",
-                                "value": "job-profile-refresh"
-                            },
-                            {
-                                "name": "Values__delete-topic-name",
-                                "value": "job-profile-delete-topic"
-                            },
-                            {
-                                "name": "Values__delete-subscription-name",
-                                "value": "job-profile-delete"
+                                "name": "Values__job-profiles-refresh-subscription",
+                                "value": "[variables('refreshSubscriptionName')]"
                             },
                             {
                                 "name": "jobProfileClientOptions__Timeout",
-                                "value": "00:00:30"
+                                "value": "00:00:10"
                             },
                             {
                                 "name": "jobProfileClientOptions__BaseAddress",
@@ -507,7 +498,31 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[variables('mainTopicName')]",
+            "name": "[variables('cmsSubscriptionName')]",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('appSharedResourceGroup')]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic-subscription.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "serviceBusNamespaceName": {
+                        "value": "[parameters('serviceBusNamespace')]"
+                    },
+                    "serviceBusTopicName": {
+                        "value": "[variables('cmsTopicName')]"
+                    },
+                    "serviceBusTopicSubscriptionName": {
+                        "value": "[variables('cmsSubscriptionName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "[variables('refreshTopicName')]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('appSharedResourceGroup')]",
             "properties": {
@@ -521,14 +536,14 @@
                         "value": "[parameters('serviceBusNamespace')]"
                     },
                     "serviceBusTopicName": {
-                        "value": "[variables('mainTopicName')]"
+                        "value": "[variables('refreshTopicName')]"
                     }
                 }
             }
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[variables('postSubscriptionName')]",
+            "name": "[variables('refreshSubscriptionName')]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('appSharedResourceGroup')]",
             "properties": {
@@ -542,90 +557,15 @@
                         "value": "[parameters('serviceBusNamespace')]"
                     },
                     "serviceBusTopicName": {
-                        "value": "[variables('mainTopicName')]"
+                        "value": "[variables('refreshTopicName')]"
                     },
                     "serviceBusTopicSubscriptionName": {
-                        "value": "[variables('postSubscriptionName')]"
+                        "value": "[variables('refreshSubscriptionName')]"
                     }
                 }
             },
             "dependsOn": [
-                "[variables('mainTopicName')]"
-            ]
-        },
-        {
-            "apiVersion": "2017-05-10",
-            "name": "[variables('patchSubscriptionName')]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('appSharedResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic-subscription.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "serviceBusNamespaceName": {
-                        "value": "[parameters('serviceBusNamespace')]"
-                    },
-                    "serviceBusTopicName": {
-                        "value": "[variables('mainTopicName')]"
-                    },
-                    "serviceBusTopicSubscriptionName": {
-                        "value": "[variables('patchSubscriptionName')]"
-                    }
-                }
-            },
-            "dependsOn": [
-                "[variables('mainTopicName')]"
-            ]
-        },
-        {
-            "apiVersion": "2017-05-10",
-            "name": "[variables('deleteTopicName')]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('appSharedResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "serviceBusNamespaceName": {
-                        "value": "[parameters('serviceBusNamespace')]"
-                    },
-                    "serviceBusTopicName": {
-                        "value": "[variables('deleteTopicName')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2017-05-10",
-            "name": "[variables('deleteSubscriptionName')]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('appSharedResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic-subscription.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "serviceBusNamespaceName": {
-                        "value": "[parameters('serviceBusNamespace')]"
-                    },
-                    "serviceBusTopicName": {
-                        "value": "[variables('deleteTopicName')]"
-                    },
-                    "serviceBusTopicSubscriptionName": {
-                        "value": "[variables('deleteSubscriptionName')]"
-                    }
-                }
-            },
-            "dependsOn": [
-                "[variables('deleteTopicName')]"
+                "[variables('refreshTopicName')]"
             ]
         }
     ],


### PR DESCRIPTION
Creates cmsSubscriptionName on cmsTopicName (assumes cmsTopicName already exists) + refreshSubscriptionName and refreshTopicName. This replaces previous topics and subscriptions.

Remove old function app settings for topics + subscriptions and replaced with
* Values__cms-messages-topic: variables('cmsTopicName')
* Values__cms-messages-subscription: variables('cmsSubscriptionName')
* Values__job-profiles-refresh-topic: variables('refreshTopicName')
* Values__job-profiles-refresh-subscription: variables('refreshSubscriptionName')

Changed segment timeout to 10 seconds (app gateway is set to 30 seconds and this needs to respond within then)