### PR TITLE
Release v1.1.44.2

### DIFF
--- a/DFC.App.JobProfile.Data/Contracts/ISegmentDataModel.cs
+++ b/DFC.App.JobProfile.Data/Contracts/ISegmentDataModel.cs
@@ -1,6 +1,0 @@
-﻿namespace DFC.App.JobProfile.Data.Contracts
-{
-    public interface ISegmentDataModel
-    {
-    }
-}

--- a/DFC.App.JobProfile.Data/Contracts/ISegmentLoadService.cs
+++ b/DFC.App.JobProfile.Data/Contracts/ISegmentLoadService.cs
@@ -1,9 +1,0 @@
-﻿using System.Threading.Tasks;
-
-namespace DFC.App.JobProfile.Data.Contracts
-{
-    public interface ISegmentLoadService<T>
-    {
-        Task<T> LoadAsync();
-    }
-}

--- a/DFC.App.JobProfile.Data/DFC.App.JobProfile.Data.csproj
+++ b/DFC.App.JobProfile.Data/DFC.App.JobProfile.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/DFC.App.JobProfile.Data/HttpClientPolicies/SegmentClientOptions.cs
+++ b/DFC.App.JobProfile.Data/HttpClientPolicies/SegmentClientOptions.cs
@@ -11,5 +11,7 @@ namespace DFC.App.JobProfile.Data.HttpClientPolicies
         public string OfflineHtml { get; set; }
 
         public TimeSpan Timeout { get; set; } = new TimeSpan(0, 0, 10);         // default to 10 seconds
+
+        public string Name { get; set; }
     }
 }

--- a/DFC.App.JobProfile.IntegrationTests/DFC.App.JobProfile.IntegrationTests.csproj
+++ b/DFC.App.JobProfile.IntegrationTests/DFC.App.JobProfile.IntegrationTests.csproj
@@ -42,9 +42,6 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
     <None Update="appsettings.json">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="appsettings-template.json">

--- a/DFC.App.JobProfile.IntegrationTests/DFC.App.JobProfile.IntegrationTests.csproj
+++ b/DFC.App.JobProfile.IntegrationTests/DFC.App.JobProfile.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,15 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.4.1" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.MessageFunctionApp/DFC.App.JobProfile.MessageFunctionApp.csproj
+++ b/DFC.App.JobProfile.MessageFunctionApp/DFC.App.JobProfile.MessageFunctionApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -11,13 +11,13 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="DFC.Functions.DI.Standard" Version="0.1.0" />
-    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.1.1" />
+    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
@@ -32,14 +32,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
     <None Update="local.settings-template.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-    <None Update="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>

--- a/DFC.App.JobProfile.MessageFunctionApp/Services/HttpClientService.cs
+++ b/DFC.App.JobProfile.MessageFunctionApp/Services/HttpClientService.cs
@@ -46,7 +46,7 @@ namespace DFC.App.JobProfile.MessageFunctionApp.Services
             return default;
         }
 
-        public async Task<HttpStatusCode> PatchAsync<TInput>(TInput patchModel, string patchTypeEndpoint)
+        public async Task<HttpStatusCode> PatchAsync<TInput>(TInput patchModel, string patchTypeEndpoint = "metadata", int retryCount = 0)
             where TInput : BaseJobProfile
         {
             if (patchModel is null)
@@ -69,6 +69,11 @@ namespace DFC.App.JobProfile.MessageFunctionApp.Services
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     logService.LogError($"Failure status code '{response.StatusCode}' received with content '{responseContent}', for patch type {typeof(T)}, Id: {patchModel.JobProfileId}");
+
+                    if (response.StatusCode == HttpStatusCode.PreconditionFailed && retryCount <= 5)
+                    {
+                        return await PatchAsync(patchModel, patchTypeEndpoint, retryCount++).ConfigureAwait(false);
+                    }
 
                     response.EnsureSuccessStatusCode();
                 }
@@ -95,7 +100,7 @@ namespace DFC.App.JobProfile.MessageFunctionApp.Services
             return response.StatusCode;
         }
 
-        public async Task<HttpStatusCode> PostAsync<TInput>(TInput postModel, string postEndpoint)
+        public async Task<HttpStatusCode> PostAsync<TInput>(TInput postModel, string postEndpoint = "profile", int retryCount = 0)
             where TInput : BaseJobProfile
         {
             if (postModel is null)
@@ -113,6 +118,11 @@ namespace DFC.App.JobProfile.MessageFunctionApp.Services
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     logService.LogError($"Failure status code '{response.StatusCode}' received with content '{responseContent}', for POST type {typeof(T)}, Id: {postModel.JobProfileId}.");
+
+                    if (response.StatusCode == HttpStatusCode.PreconditionFailed && retryCount <= 5)
+                    {
+                        return await PostAsync(postModel, postEndpoint, retryCount++).ConfigureAwait(false);
+                    }
 
                     response.EnsureSuccessStatusCode();
                 }

--- a/DFC.App.JobProfile.MessageFunctionApp/Services/IHttpClientService.cs
+++ b/DFC.App.JobProfile.MessageFunctionApp/Services/IHttpClientService.cs
@@ -10,12 +10,12 @@ namespace DFC.App.JobProfile.MessageFunctionApp.Services
     {
         Task<TModel> GetByIdAsync(Guid id);
 
-        Task<HttpStatusCode> PostAsync<TInput>(TInput postModel, string postEndpoint = "profile")
+        Task<HttpStatusCode> PostAsync<TInput>(TInput postModel, string postEndpoint = "profile", int retryCount = 0)
             where TInput : BaseJobProfile;
 
         Task<HttpStatusCode> DeleteAsync(Guid id);
 
-        Task<HttpStatusCode> PatchAsync<TInput>(TInput patchModel, string patchTypeEndpoint = "metadata")
+        Task<HttpStatusCode> PatchAsync<TInput>(TInput patchModel, string patchTypeEndpoint = "metadata", int retryCount = 0)
             where TInput : BaseJobProfile;
     }
 }

--- a/DFC.App.JobProfile.ProfileService.UnitTests/DFC.App.JobProfile.ProfileService.UnitTests.csproj
+++ b/DFC.App.JobProfile.ProfileService.UnitTests/DFC.App.JobProfile.ProfileService.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.4.1" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.ProfileService.UnitTests/ProfileServiceTests/ProfileServiceGetByAlternativeNameTests.cs
+++ b/DFC.App.JobProfile.ProfileService.UnitTests/ProfileServiceTests/ProfileServiceGetByAlternativeNameTests.cs
@@ -52,7 +52,7 @@ namespace DFC.App.JobProfile.ProfileService.UnitTests.ProfileServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await jobProfileService.GetByAlternativeNameAsync(null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: alternativeName", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'alternativeName')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.JobProfile.ProfileService.UnitTests/ProfileServiceTests/ProfileServiceGetByNameTests.cs
+++ b/DFC.App.JobProfile.ProfileService.UnitTests/ProfileServiceTests/ProfileServiceGetByNameTests.cs
@@ -53,7 +53,7 @@ namespace DFC.App.JobProfile.ProfileService.UnitTests.ProfileServiceTests
             var exceptionResult = await Assert.ThrowsAsync<ArgumentNullException>(async () => await jobProfileService.GetByNameAsync(null).ConfigureAwait(false)).ConfigureAwait(false);
 
             // assert
-            Assert.Equal("Value cannot be null.\r\nParameter name: canonicalName", exceptionResult.Message);
+            Assert.Equal("Value cannot be null. (Parameter 'canonicalName')", exceptionResult.Message);
         }
 
         [Fact]

--- a/DFC.App.JobProfile.ProfileService/DFC.App.JobProfile.ProfileService.csproj
+++ b/DFC.App.JobProfile.ProfileService/DFC.App.JobProfile.ProfileService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -12,12 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.6" />
+    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.ProfileService/JobProfileService.cs
+++ b/DFC.App.JobProfile.ProfileService/JobProfileService.cs
@@ -153,14 +153,15 @@ namespace DFC.App.JobProfile.ProfileService
             if (existingItem is null)
             {
                 segmentData.Markup = !string.IsNullOrEmpty(segmentData.Markup?.Value) ? segmentData.Markup : offlineSegmentData.OfflineMarkup;
-                segmentData.Json = segmentData.Json ?? offlineSegmentData.OfflineJson;
+                segmentData.Json ??= offlineSegmentData.OfflineJson;
                 existingJobProfile.Segments.Add(segmentData);
             }
             else
             {
                 var index = existingJobProfile.Segments.IndexOf(existingItem);
-                segmentData.Markup = !string.IsNullOrEmpty(segmentData.Markup?.Value) ? segmentData.Markup : (!string.IsNullOrEmpty(existingItem.Markup?.Value) ? existingItem.Markup : offlineSegmentData.OfflineMarkup);
-                segmentData.Json = segmentData.Json is null ? existingItem.Json ?? offlineSegmentData.OfflineJson : segmentData.Json;
+                var fallbackMarkup = !string.IsNullOrEmpty(existingItem.Markup?.Value) ? existingItem.Markup : offlineSegmentData.OfflineMarkup;
+                segmentData.Markup = !string.IsNullOrEmpty(segmentData.Markup?.Value) ? segmentData.Markup : fallbackMarkup;
+                segmentData.Json ??= existingItem.Json ?? offlineSegmentData.OfflineJson;
 
                 existingJobProfile.Segments[index] = segmentData;
             }

--- a/DFC.App.JobProfile.ProfileService/RefreshSegmentService{TClientOptions}.cs
+++ b/DFC.App.JobProfile.ProfileService/RefreshSegmentService{TClientOptions}.cs
@@ -62,6 +62,8 @@ namespace DFC.App.JobProfile.ProfileService.SegmentServices
                 {
                     logService.LogError($"{nameof(HealthCheckAsync)}: Error loading health data from {url}: {response.StatusCode}");
 
+                    var aa = SegmentClientOptions.BaseAddress;
+
                     var result = new HealthCheckItems
                     {
                         Source = SegmentClientOptions.BaseAddress,
@@ -69,7 +71,7 @@ namespace DFC.App.JobProfile.ProfileService.SegmentServices
                         {
                             new HealthCheckItem
                             {
-                                Service = SegmentClientOptions.BaseAddress.ToString(),
+                                Service = SegmentClientOptions.Name,
                                 Message = $"No health response from {SegmentClientOptions.BaseAddress.ToString()} app",
                             },
                         },
@@ -89,7 +91,7 @@ namespace DFC.App.JobProfile.ProfileService.SegmentServices
                     {
                         new HealthCheckItem
                         {
-                            Service = SegmentClientOptions.BaseAddress.ToString(),
+                            Service = SegmentClientOptions.Name,
                             Message = $"{ex.GetType().Name}: {ex.Message}",
                         },
                     },

--- a/DFC.App.JobProfile.ProfileService/RefreshSegmentService{TClientOptions}.cs
+++ b/DFC.App.JobProfile.ProfileService/RefreshSegmentService{TClientOptions}.cs
@@ -147,13 +147,5 @@ namespace DFC.App.JobProfile.ProfileService.SegmentServices
                 httpClient.DefaultRequestHeaders.Add(HeaderName.CorrelationId, correlationIdProvider.CorrelationId);
             }
         }
-
-        private void ConfigureHttpClient()
-        {
-            if (!httpClient.DefaultRequestHeaders.Contains(HeaderName.CorrelationId))
-            {
-                httpClient.DefaultRequestHeaders.Add(HeaderName.CorrelationId, correlationIdProvider.CorrelationId);
-            }
-        }
     }
 }

--- a/DFC.App.JobProfile.ProfileService/SegmentService.cs
+++ b/DFC.App.JobProfile.ProfileService/SegmentService.cs
@@ -1,5 +1,4 @@
 ﻿using DFC.App.JobProfile.Data;
-using DFC.App.JobProfile.Data.Contracts;
 using DFC.App.JobProfile.Data.Contracts.SegmentServices;
 using DFC.App.JobProfile.Data.HttpClientPolicies;
 using DFC.App.JobProfile.Data.Models;
@@ -152,26 +151,26 @@ namespace DFC.App.JobProfile.ProfileService
 
         private IList<HealthCheckItem> GetHealthResults(Task<HealthCheckItems> task)
         {
-            if (task != null)
+            if (task == null)
             {
-                if (task.IsCompletedSuccessfully && task.Result?.HealthItems?.Count > 0)
-                {
-                    return task.Result.HealthItems;
-                }
-                else
-                {
-                    return new List<HealthCheckItem>()
-                    {
-                        new HealthCheckItem
-                        {
-                            Service = task.Result.Source.ToString(),
-                            Message = $"No health response from {task.Result.Source.ToString()} app",
-                        },
-                    };
-                }
+                return new List<HealthCheckItem>();
             }
 
-            return null;
+            if (task.IsCompletedSuccessfully && task.Result?.HealthItems?.Count > 0)
+            {
+                return task.Result.HealthItems;
+            }
+            else
+            {
+                return new List<HealthCheckItem>
+                {
+                    new HealthCheckItem
+                    {
+                        Service = task.GetAwaiter().GetResult().Source.ToString(),
+                        Message = $"No health response from {task.Result.Source.ToString()} app",
+                    },
+                };
+            }
         }
 
         private async Task<SegmentModel> GetSegmentDataAsync<T>(ISegmentRefreshService<T> segmentService, RefreshJobProfileSegment toRefresh)

--- a/DFC.App.JobProfile.Repository.CosmosDb/CosmosRepository.cs
+++ b/DFC.App.JobProfile.Repository.CosmosDb/CosmosRepository.cs
@@ -80,9 +80,16 @@ namespace DFC.App.JobProfile.Repository.CosmosDb
             var ac = new AccessCondition { Condition = model.Etag, Type = AccessConditionType.IfMatch };
             var pk = new PartitionKey(model.PartitionKey);
 
-            var result = await documentClient.UpsertDocumentAsync(DocumentCollectionUri, model, new RequestOptions { AccessCondition = ac, PartitionKey = pk }).ConfigureAwait(false);
+            try
+            {
+                var result = await documentClient.UpsertDocumentAsync(DocumentCollectionUri, model, new RequestOptions { AccessCondition = ac, PartitionKey = pk }).ConfigureAwait(false);
 
-            return result.StatusCode;
+                return result.StatusCode;
+            }
+            catch (DocumentClientException e) when (e.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                return HttpStatusCode.PreconditionFailed;
+            }
         }
 
         public async Task<HttpStatusCode> DeleteAsync(Guid documentId)

--- a/DFC.App.JobProfile.Repository.CosmosDb/DFC.App.JobProfile.Repository.CosmosDb.csproj
+++ b/DFC.App.JobProfile.Repository.CosmosDb/DFC.App.JobProfile.Repository.CosmosDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/HealthControllerTests/HealthControllerHealthTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/HealthControllerTests/HealthControllerHealthTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Mime;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.HealthControllerTests
@@ -15,12 +16,11 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.HealthControllerTests
     public class HealthControllerHealthTests : BaseHealthController
     {
         [Fact]
-        public async void HealthControllerHealthReturnsSuccessWhenhealthy()
+        public async Task HealthControllerHealthReturnsSuccessWhenhealthy()
         {
             // Arrange
-            bool expectedResult = true;
+            const bool expectedResult = true;
             var controller = BuildHealthController(MediaTypeNames.Application.Json);
-
             A.CallTo(() => FakeJobProfileService.PingAsync()).Returns(expectedResult);
 
             // Act
@@ -40,12 +40,11 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.HealthControllerTests
         }
 
         [Fact]
-        public async void HealthControllerHealthReturnsServiceUnavailableWhenUnhealthy()
+        public async Task HealthControllerHealthReturnsServiceUnavailableWhenUnhealthy()
         {
             // Arrange
-            bool expectedResult = false;
+            const bool expectedResult = false;
             var controller = BuildHealthController(MediaTypeNames.Application.Json);
-
             A.CallTo(() => FakeJobProfileService.PingAsync()).Returns(expectedResult);
 
             // Act
@@ -53,20 +52,17 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.HealthControllerTests
 
             // Assert
             A.CallTo(() => FakeJobProfileService.PingAsync()).MustHaveHappenedOnceExactly();
-
             var statusResult = Assert.IsType<StatusCodeResult>(result);
-
-            A.Equals((int)HttpStatusCode.ServiceUnavailable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.ServiceUnavailable, statusResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Fact]
-        public async void HealthControllerHealthReturnsServiceUnavailableWhenException()
+        public async Task HealthControllerHealthReturnsServiceUnavailableWhenException()
         {
             // Arrange
             var controller = BuildHealthController(MediaTypeNames.Application.Json);
-
             A.CallTo(() => FakeJobProfileService.PingAsync()).Throws<Exception>();
 
             // Act
@@ -74,10 +70,8 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.HealthControllerTests
 
             // Assert
             A.CallTo(() => FakeJobProfileService.PingAsync()).MustHaveHappenedOnceExactly();
-
             var statusResult = Assert.IsType<StatusCodeResult>(result);
-
-            A.Equals((int)HttpStatusCode.ServiceUnavailable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.ServiceUnavailable, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
@@ -46,13 +46,19 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
         protected ISegmentService FakeSegmentService { get; }
 
-        protected ProfileController BuildProfileController(string mediaTypeName = MediaTypeNames.Application.Json, IMapper mapper = null)
+        protected ProfileController BuildProfileController(
+            string mediaTypeName = MediaTypeNames.Application.Json,
+            IMapper mapper = null,
+            string host = "localhost",
+            string[] whitelist = null)
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[HeaderNames.Accept] = mediaTypeName;
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString(host);
 
             var feedbackLinks = A.Fake<FeedbackLinks>();
-            var controller = new ProfileController(FakeLogger, FakeJobProfileService, mapper ?? FakeMapper, feedbackLinks, FakeSegmentService)
+            var controller = new ProfileController(FakeLogger, FakeJobProfileService, mapper ?? FakeMapper, feedbackLinks, FakeSegmentService, whitelist)
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
@@ -1,5 +1,7 @@
-﻿using DFC.App.JobProfile.Controllers;
+﻿using AutoMapper;
+using DFC.App.JobProfile.Controllers;
 using DFC.App.JobProfile.Data.Contracts;
+using DFC.App.JobProfile.Models;
 using DFC.Logger.AppInsights.Contracts;
 using FakeItEasy;
 using Microsoft.AspNetCore.Http;
@@ -13,42 +15,45 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 {
     public abstract class BaseProfileController
     {
-        public BaseProfileController()
+        protected BaseProfileController()
         {
             FakeLogger = A.Fake<ILogService>();
             FakeJobProfileService = A.Fake<IJobProfileService>();
-            FakeMapper = A.Fake<AutoMapper.IMapper>();
+            FakeMapper = A.Fake<IMapper>();
+            FakeSegmentService = A.Fake<ISegmentService>();
         }
 
-        public static IEnumerable<object[]> HtmlMediaTypes => new List<object[]>
+        public static IEnumerable<object[]> HtmlMediaTypes => new List<string[]>
         {
-            new string[] { "*/*" },
-            new string[] { MediaTypeNames.Text.Html },
+            new[] { "*/*" },
+            new[] { MediaTypeNames.Text.Html },
         };
 
-        public static IEnumerable<object[]> InvalidMediaTypes => new List<object[]>
+        public static IEnumerable<object[]> InvalidMediaTypes => new List<string[]>
         {
-            new string[] { MediaTypeNames.Text.Plain },
+            new[] { MediaTypeNames.Text.Plain },
         };
 
-        public static IEnumerable<object[]> JsonMediaTypes => new List<object[]>
+        public static IEnumerable<object[]> JsonMediaTypes => new List<string[]>
         {
-            new string[] { MediaTypeNames.Application.Json },
+            new[] { MediaTypeNames.Application.Json },
         };
 
         protected ILogService FakeLogger { get; }
 
         protected IJobProfileService FakeJobProfileService { get; }
 
-        protected AutoMapper.IMapper FakeMapper { get; }
+        protected IMapper FakeMapper { get; }
 
-        protected ProfileController BuildProfileController(string mediaTypeName)
+        protected ISegmentService FakeSegmentService { get; }
+
+        protected ProfileController BuildProfileController(string mediaTypeName = MediaTypeNames.Application.Json, IMapper mapper = null)
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers[HeaderNames.Accept] = mediaTypeName;
 
             var feedbackLinks = A.Fake<FeedbackLinks>();
-            var controller = new ProfileController(FakeLogger, FakeJobProfileService, FakeMapper, feedbackLinks)
+            var controller = new ProfileController(FakeLogger, FakeJobProfileService, mapper ?? FakeMapper, feedbackLinks, FakeSegmentService)
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/BaseProfileController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
 using System.Collections.Generic;
 using System.Net.Mime;
-using DFC.App.JobProfile.Models;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 {

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerBodyTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerBodyTests.cs
@@ -1,10 +1,16 @@
-﻿using DFC.App.JobProfile.Data.Models;
+﻿using DFC.App.JobProfile.Data;
+using DFC.App.JobProfile.Data.Models;
+using DFC.App.JobProfile.Exceptions;
 using DFC.App.JobProfile.ViewModels;
 using FakeItEasy;
 using FluentAssertions;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Net.Mime;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -12,191 +18,357 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     [Trait("Profile Controller", "Body Tests")]
     public class ProfileControllerBodyTests : BaseProfileController
     {
+        private const string FakeArticleName = "an-article-name";
+
+        private static BodyViewModel DefaultBodyViewModel => new BodyViewModel
+        {
+            CanonicalName = FakeArticleName,
+            Segments = new List<SegmentModel>
+            {
+                new SegmentModel
+                {
+                    Segment = JobProfileSegment.Overview,
+                    Markup = new HtmlString("someContent"),
+                },
+                new SegmentModel
+                {
+                    Segment = JobProfileSegment.WhatItTakes,
+                    Markup = new HtmlString("someContent"),
+                },
+                new SegmentModel
+                {
+                    Segment = JobProfileSegment.HowToBecome,
+                    Markup = new HtmlString("someContent"),
+                },
+            },
+        };
+
+        public static IEnumerable<object[]> EmptyCriticalSegmentModelInput()
+        {
+            yield return new object[]
+            {
+                new List<SegmentModel>
+                {
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.Overview,
+                        Markup = new HtmlString(string.Empty),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.HowToBecome,
+                        Markup = new HtmlString("someContent"),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.WhatItTakes,
+                        Markup = new HtmlString("someContent"),
+                    },
+                },
+            };
+            yield return new object[]
+            {
+                new List<SegmentModel>
+                {
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.Overview,
+                        Markup = new HtmlString("someContent"),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.HowToBecome,
+                        Markup = new HtmlString(string.Empty),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.WhatItTakes,
+                        Markup = new HtmlString("someContent"),
+                    },
+                },
+            };
+            yield return new object[]
+            {
+                new List<SegmentModel>
+                {
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.Overview,
+                        Markup = new HtmlString("someContent"),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.HowToBecome,
+                        Markup = new HtmlString("someContent"),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.WhatItTakes,
+                        Markup = new HtmlString(string.Empty),
+                    },
+                },
+            };
+        }
+
+        public static IEnumerable<object[]> EmptyNonCriticalSegmentModelInput()
+        {
+            yield return new object[]
+            {
+                DefaultBodyViewModel.Segments.Append(new SegmentModel
+                {
+                    Segment = JobProfileSegment.RelatedCareers,
+                    Markup = new HtmlString(string.Empty),
+                }).ToList(),
+            };
+            yield return new object[]
+            {
+                DefaultBodyViewModel.Segments.Append(new SegmentModel
+                {
+                    Segment = JobProfileSegment.CurrentOpportunities,
+                    Markup = new HtmlString(string.Empty),
+                }).ToList(),
+            };
+            yield return new object[]
+            {
+                DefaultBodyViewModel.Segments.Append(new SegmentModel
+                {
+                    Segment = JobProfileSegment.WhatYouWillDo,
+                    Markup = new HtmlString(string.Empty),
+                }).ToList(),
+            };
+            yield return new object[]
+            {
+                DefaultBodyViewModel.Segments.Append(new SegmentModel
+                {
+                    Segment = JobProfileSegment.CareerPathsAndProgression,
+                    Markup = new HtmlString(string.Empty),
+                }).ToList(),
+            };
+        }
+
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void JobProfileControllerBodyHtmlReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerBodyHtmlReturnsSuccess(string mediaTypeName)
         {
             // Arrange
-            const string article = "an-article-name";
             var expectedResult = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
-            expectedResult.CanonicalName = article;
+            expectedResult.CanonicalName = FakeArticleName;
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).Returns(A.Fake<BodyViewModel>());
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(DefaultBodyViewModel);
 
             // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var viewResult = Assert.IsType<ViewResult>(result);
-            var model = Assert.IsAssignableFrom<BodyViewModel>(viewResult.ViewData.Model);
+            Assert.IsAssignableFrom<BodyViewModel>(viewResult.ViewData.Model);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void JobProfileControllerBodyJsonReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerBodyJsonReturnsSuccess(string mediaTypeName)
         {
             // Arrange
-            const string article = "an-article-name";
             var expectedResult = A.Dummy<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
-            expectedResult.CanonicalName = article;
+            expectedResult.CanonicalName = FakeArticleName;
             expectedResult.Segments = new List<SegmentModel>();
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).Returns(A.Fake<BodyViewModel>());
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(DefaultBodyViewModel);
 
             // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var jsonResult = Assert.IsType<OkObjectResult>(result);
-            var model = Assert.IsAssignableFrom<List<SegmentModel>>(jsonResult.Value);
+            Assert.IsAssignableFrom<List<SegmentModel>>(jsonResult.Value);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void JobProfileControllerBodyJsonReturnsRedirectWhenAlternateArticleExists(string mediaTypeName)
+        [MemberData(nameof(HtmlMediaTypes))]
+        public async Task JobProfileControllerBodyJsonAndHtmlReturnsRedirectWhenAlternateArticleExists(
+            string mediaTypeName)
         {
             // Arrange
-            const string article = "an-article-name";
-            Data.Models.JobProfileModel expectedResult = null;
             var expectedAlternativeResult = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns(expectedAlternativeResult);
+            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns((JobProfileModel)null);
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored))
+                .Returns(expectedAlternativeResult);
 
             // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored))
+                .MustHaveHappenedOnceExactly();
 
             var statusResult = Assert.IsType<RedirectResult>(result);
-
             statusResult.Url.Should().NotBeNullOrWhiteSpace();
-            A.Equals(true, statusResult.Permanent);
+            Assert.True(statusResult.Permanent);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void JobProfileControllerBodyHtmlReturnsRedirectWhenAlternateArticleExists(string mediaTypeName)
-        {
-            // Arrange
-            const string article = "an-article-name";
-            Data.Models.JobProfileModel expectedResult = null;
-            var expectedAlternativeResult = A.Fake<JobProfileModel>();
-            var controller = BuildProfileController(mediaTypeName);
-
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns(expectedAlternativeResult);
-
-            // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
-
-            // Assert
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-
-            var statusResult = Assert.IsType<RedirectResult>(result);
-
-            statusResult.Url.Should().NotBeNullOrWhiteSpace();
-            A.Equals(true, statusResult.Permanent);
-
-            controller.Dispose();
-        }
-
-        [Theory]
-        [MemberData(nameof(HtmlMediaTypes))]
-        public async void JobProfileControllerBodyHtmlReturnsNoContentWhenNoAlternateArticle(string mediaTypeName)
-        {
-            // Arrange
-            const string article = "an-article-name";
-            Data.Models.JobProfileModel expectedResult = null;
-            Data.Models.JobProfileModel expectedAlternativeResult = null;
-            var controller = BuildProfileController(mediaTypeName);
-
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns(expectedAlternativeResult);
-
-            // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
-
-            // Assert
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-
-            var viewResult = Assert.IsType<NotFoundResult>(result);
-
-            controller.Dispose();
-        }
-
-        [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void JobProfileControllerBodyJsonReturnsNoContentWhenNoAlternateArticle(string mediaTypeName)
+        public async Task JobProfileControllerBodyHtmlAndJsonReturnsNoContentWhenNoAlternateArticle(
+            string mediaTypeName)
         {
             // Arrange
-            const string article = "an-article-name";
-            Data.Models.JobProfileModel expectedResult = null;
-            Data.Models.JobProfileModel expectedAlternativeResult = null;
             var controller = BuildProfileController(mediaTypeName);
 
-            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns(expectedAlternativeResult);
+            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns((JobProfileModel)null);
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored))
+                .Returns((JobProfileModel)null);
 
             // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-
-            var jsonResult = Assert.IsType<NotFoundResult>(result);
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored))
+                .MustHaveHappenedOnceExactly();
+            Assert.IsType<NotFoundResult>(result);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(InvalidMediaTypes))]
-        public async void JobProfileControllerBodyReturnsNotAcceptable(string mediaTypeName)
+        public async Task JobProfileControllerBodyReturnsNotAcceptable(string mediaTypeName)
         {
             // Arrange
-            const string article = "an-article-name";
             var expectedResult = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
-            expectedResult.CanonicalName = article;
+            expectedResult.CanonicalName = FakeArticleName;
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).Returns(A.Fake<BodyViewModel>());
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(DefaultBodyViewModel);
 
             // Act
-            var result = await controller.Body(article).ConfigureAwait(false);
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var statusResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
+
+            controller.Dispose();
+        }
+
+        [Fact]
+        public async Task BodyThrowsInvalidProfileExceptionWhenCriticalSegmentDoesNotExist()
+        {
+            // Arrange
+            var controller = BuildProfileController(MediaTypeNames.Application.Json);
+            var bodyViewModel = new BodyViewModel
+            {
+                CanonicalName = FakeArticleName,
+                Segments = new List<SegmentModel>
+                {
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.WhatItTakes,
+                        Markup = new HtmlString("someContent"),
+                    },
+                    new SegmentModel
+                    {
+                        Segment = JobProfileSegment.HowToBecome,
+                        Markup = new HtmlString("someContent"),
+                    },
+                },
+            };
+
+            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(A.Fake<JobProfileModel>());
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns((JobProfileModel)null);
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(bodyViewModel);
+
+            // Act
+            await Assert.ThrowsAsync<InvalidProfileException>(async () => await controller.Body(FakeArticleName).ConfigureAwait(false)).ConfigureAwait(false);
+
+            controller.Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyCriticalSegmentModelInput))]
+        public async Task BodyThrowsInvalidProfileExceptionWhenCriticalSegmentsHaveNoMarkup(List<SegmentModel> segments)
+        {
+            // Arrange
+            var controller = BuildProfileController(MediaTypeNames.Application.Json);
+            var bodyViewModel = new BodyViewModel
+            {
+                CanonicalName = FakeArticleName,
+                Segments = segments,
+            };
+
+            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(A.Fake<JobProfileModel>());
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns((JobProfileModel)null);
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(bodyViewModel);
+
+            // Act
+            await Assert.ThrowsAsync<InvalidProfileException>(async () => await controller.Body(FakeArticleName).ConfigureAwait(false)).ConfigureAwait(false);
+
+            controller.Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyNonCriticalSegmentModelInput))]
+        public async Task BodyReturnsOfflineMarkupWhenNonCriticalSegmentsHaveNoMarkup(List<SegmentModel> segments)
+        {
+            // Arrange
+            var controller = BuildProfileController(MediaTypeNames.Application.Json);
+            var bodyViewModel = new BodyViewModel
+            {
+                CanonicalName = FakeArticleName,
+                Segments = segments,
+            };
+
+            var offlineSegmentModel = new OfflineSegmentModel
+            {
+                OfflineMarkup = new HtmlString("<h1>Some offline markup for this non-critical segment</h1>"),
+            };
+
+            A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(A.Fake<JobProfileModel>());
+            A.CallTo(() => FakeJobProfileService.GetByAlternativeNameAsync(A<string>.Ignored)).Returns((JobProfileModel)null);
+            A.CallTo(() => FakeMapper.Map<BodyViewModel>(A<JobProfileModel>.Ignored)).Returns(bodyViewModel);
+            A.CallTo(() => FakeSegmentService.GetOfflineSegment(A<JobProfileSegment>.Ignored)).Returns(offlineSegmentModel);
+
+            // Act
+            var result = await controller.Body(FakeArticleName).ConfigureAwait(false);
+
+            // Assert
+            var okObjectResult = result as OkObjectResult;
+            var resultViewModel = Assert.IsAssignableFrom<BodyViewModel>(okObjectResult?.Value);
+            var nonCriticalSegment = segments.FirstOrDefault(s => s.Segment != JobProfileSegment.Overview && s.Segment != JobProfileSegment.HowToBecome && s.Segment != JobProfileSegment.WhatItTakes);
+            var resultSegmentModel = resultViewModel.Segments.FirstOrDefault(s => s.Segment == nonCriticalSegment?.Segment);
+
+            Assert.Equal((int)HttpStatusCode.OK, okObjectResult.StatusCode);
+            A.CallTo(() => FakeSegmentService.GetOfflineSegment(A<JobProfileSegment>.Ignored)).MustHaveHappenedOnceExactly();
+            Assert.Equal(offlineSegmentModel.OfflineMarkup.Value, resultSegmentModel?.Markup.Value);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerCreateOrUpdateTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerCreateOrUpdateTests.cs
@@ -2,6 +2,7 @@
 using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -11,7 +12,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerCreateOrUpdateReturnsSuccessForCreate(string mediaTypeName)
+        public async Task ProfileControllerCreateOrUpdateReturnsSuccessForCreate(string mediaTypeName)
         {
             // Arrange
             var jobProfileModel = A.Fake<JobProfileModel>();
@@ -27,14 +28,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.Created, statusCodeResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.Created, statusCodeResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerCreateOrUpdateReturnsSuccessForUpdate(string mediaTypeName)
+        public async Task ProfileControllerCreateOrUpdateReturnsSuccessForUpdate(string mediaTypeName)
         {
             // Arrange
             var jobProfileModel = A.Fake<JobProfileModel>();
@@ -50,17 +51,17 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerCreateOrUpdateReturnsBadResultWhenModelIsNull(string mediaTypeName)
+        public async Task ProfileControllerCreateOrUpdateReturnsBadResultWhenModelIsNull(string mediaTypeName)
         {
             // Arrange
-            Data.Models.JobProfileModel jobProfileModel = null;
+            JobProfileModel jobProfileModel = null;
             var controller = BuildProfileController(mediaTypeName);
 
             // Act
@@ -69,17 +70,17 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             // Assert
             var statusResult = Assert.IsType<BadRequestResult>(result);
 
-            A.Equals((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerCreateOrUpdateReturnsBadResultWhenModelIsInvalid(string mediaTypeName)
+        public async Task ProfileControllerCreateOrUpdateReturnsBadResultWhenModelIsInvalid(string mediaTypeName)
         {
             // Arrange
-            var jobProfileModel = new Data.Models.JobProfileModel();
+            var jobProfileModel = new JobProfileModel();
             var controller = BuildProfileController(mediaTypeName);
 
             controller.ModelState.AddModelError(string.Empty, "Model is not valid");
@@ -90,7 +91,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             // Assert
             var statusResult = Assert.IsType<BadRequestObjectResult>(result);
 
-            A.Equals((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerDeleteTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerDeleteTests.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -12,10 +13,10 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerDeleteReturnsSuccess(string mediaTypeName)
+        public async Task ProfileControllerDeleteReturnsSuccess(string mediaTypeName)
         {
             // Arrange
-            Guid documentId = Guid.NewGuid();
+            var documentId = Guid.NewGuid();
             var expectedResult = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
@@ -29,18 +30,18 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var okResult = Assert.IsType<OkResult>(result);
 
-            A.Equals((int)HttpStatusCode.OK, okResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, okResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerDeleteReturnsNotFound(string mediaTypeName)
+        public async Task ProfileControllerDeleteReturnsNotFound(string mediaTypeName)
         {
             // Arrange
-            Guid documentId = Guid.NewGuid();
-            Data.Models.JobProfileModel expectedResult = null;
+            var documentId = Guid.NewGuid();
+            JobProfileModel expectedResult = null;
             var controller = BuildProfileController(mediaTypeName);
 
             A.CallTo(() => FakeJobProfileService.GetByIdAsync(A<Guid>.Ignored)).Returns(expectedResult);
@@ -53,7 +54,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusResult = Assert.IsType<NotFoundResult>(result);
 
-            A.Equals((int)HttpStatusCode.NotFound, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NotFound, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerHeadTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerHeadTests.cs
@@ -22,14 +22,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var controller = BuildProfileController(mediaTypeName);
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
 
             // Act
             var result = await controller.Head(article).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var viewResult = Assert.IsType<ViewResult>(result);
             var model = Assert.IsAssignableFrom<HeadViewModel>(viewResult.ViewData.Model);
@@ -49,14 +49,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var controller = BuildProfileController(mediaTypeName);
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
 
             // Act
             var result = await controller.Head(article).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var jsonResult = Assert.IsType<OkObjectResult>(result);
             var model = Assert.IsAssignableFrom<HeadViewModel>(jsonResult.Value);
@@ -126,14 +126,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var controller = BuildProfileController(mediaTypeName);
 
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).Returns(expectedResult);
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).Returns(A.Fake<HeadViewModel>());
 
             // Act
             var result = await controller.Head(article).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.GetByNameAsync(A<string>.Ignored)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeadViewModel>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => FakeMapper.Map<HeadViewModel>(A<JobProfileModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var statusResult = Assert.IsType<StatusCodeResult>(result);
 

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerHeroTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerHeroTests.cs
@@ -4,6 +4,7 @@ using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -13,7 +14,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void JobProfileControllerHeroHtmlReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerHeroHtmlReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             const string article = "an-article-name";
@@ -33,14 +34,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeroViewModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var viewResult = Assert.IsType<ViewResult>(result);
-            var model = Assert.IsAssignableFrom<HeroViewModel>(viewResult.ViewData.Model);
+            Assert.IsAssignableFrom<HeroViewModel>(viewResult.ViewData.Model);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void JobProfileControllerHeroJsonReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerHeroJsonReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             const string article = "an-article-name";
@@ -61,14 +62,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<HeroViewModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var jsonResult = Assert.IsType<OkObjectResult>(result);
-            var model = Assert.IsAssignableFrom<List<SegmentModel>>(jsonResult.Value);
+            Assert.IsAssignableFrom<List<SegmentModel>>(jsonResult.Value);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(InvalidMediaTypes))]
-        public async void JobProfileControllerHeroReturnsNotAcceptable(string mediaTypeName)
+        public async Task JobProfileControllerHeroReturnsNotAcceptable(string mediaTypeName)
         {
             // Arrange
             const string article = "an-article-name";
@@ -89,7 +90,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerIndexTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerIndexTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -14,7 +15,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void ProfileControllerIndexHtmlReturnsSuccess(string mediaTypeName)
+        public async Task ProfileControllerIndexHtmlReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             const int resultsCount = 2;
@@ -34,14 +35,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var viewResult = Assert.IsType<ViewResult>(result);
             var model = Assert.IsAssignableFrom<IndexViewModel>(viewResult.ViewData.Model);
 
-            A.Equals(resultsCount, model.Documents.Count());
+            Assert.Equal(resultsCount, model.Documents.Count());
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerIndexJsonReturnsSuccess(string mediaTypeName)
+        public async Task ProfileControllerIndexJsonReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             const int resultsCount = 2;
@@ -61,14 +62,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var jsonResult = Assert.IsType<OkObjectResult>(result);
             var model = Assert.IsAssignableFrom<IndexViewModel>(jsonResult.Value);
 
-            A.Equals(resultsCount, model.Documents.Count());
+            Assert.Equal(resultsCount, model.Documents.Count());
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void ProfileControllerIndexHtmlReturnsSuccessWhenNoData(string mediaTypeName)
+        public async Task ProfileControllerIndexHtmlReturnsSuccessWhenNoData(string mediaTypeName)
         {
             // Arrange
             const int resultsCount = 0;
@@ -88,14 +89,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var viewResult = Assert.IsType<ViewResult>(result);
             var model = Assert.IsAssignableFrom<IndexViewModel>(viewResult.ViewData.Model);
 
-            A.Equals(null, model.Documents);
+            Assert.Null(model.Documents);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerIndexJsonReturnsSuccessWhenNoData(string mediaTypeName)
+        public async Task ProfileControllerIndexJsonReturnsSuccessWhenNoData(string mediaTypeName)
         {
             // Arrange
             const int resultsCount = 0;
@@ -115,14 +116,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var jsonResult = Assert.IsType<OkObjectResult>(result);
             var model = Assert.IsAssignableFrom<IndexViewModel>(jsonResult.Value);
 
-            A.Equals(null, model.Documents);
+            Assert.Null(model.Documents);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(InvalidMediaTypes))]
-        public async void ProfileControllerIndexReturnsNotAcceptable(string mediaTypeName)
+        public async Task ProfileControllerIndexReturnsNotAcceptable(string mediaTypeName)
         {
             // Arrange
             const int resultsCount = 0;
@@ -141,7 +142,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerPatchTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerPatchTests.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -12,12 +13,11 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerPatchReturnsSuccess(string mediaTypeName)
+        public async Task ProfileControllerPatchReturnsSuccess(string mediaTypeName)
         {
             // Arrange
-            Guid documentId = Guid.NewGuid();
+            var documentId = Guid.NewGuid();
             var jobProfileMetaDataPatchModel = new JobProfileMetadata();
-            var expectedResult = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
 
             A.CallTo(() => FakeJobProfileService.Update(A<JobProfileMetadata>.Ignored)).Returns(HttpStatusCode.OK);
@@ -30,17 +30,17 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerPatchWithNullParamReturnsBadRequest(string mediaTypeName)
+        public async Task ProfileControllerPatchWithNullParamReturnsBadRequest(string mediaTypeName)
         {
             // Arrange
-            Guid documentId = Guid.NewGuid();
+            var documentId = Guid.NewGuid();
             JobProfileMetadata jobProfileMetaDataPatchModel = null;
             var controller = BuildProfileController(mediaTypeName);
 
@@ -50,7 +50,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             // Assert
             var statusResult = Assert.IsType<BadRequestResult>(result);
 
-            A.Equals((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerPostRefreshTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerPostRefreshTests.cs
@@ -2,6 +2,7 @@
 using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -11,29 +12,27 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerPostRefreshReturnsSuccessForUpdate(string mediaTypeName)
+        public async Task ProfileControllerPostRefreshReturnsSuccessForUpdate(string mediaTypeName)
         {
             // Arrange
             var refreshJobProfileSegmentModel = A.Fake<RefreshJobProfileSegment>();
-            var existingRefreshJobProfileSegment = A.Fake<JobProfileModel>();
             var controller = BuildProfileController(mediaTypeName);
+            A.CallTo(() => FakeJobProfileService.RefreshSegmentsAsync(A<RefreshJobProfileSegment>.Ignored)).Returns(HttpStatusCode.OK);
 
             // Act
             var result = await controller.Refresh(refreshJobProfileSegmentModel).ConfigureAwait(false);
 
             // Assert
             A.CallTo(() => FakeJobProfileService.RefreshSegmentsAsync(A<RefreshJobProfileSegment>.Ignored)).MustHaveHappenedOnceExactly();
-
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result);
-
-            A.Equals((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.OK, statusCodeResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerPostRefreshReturnsBadResultWhenModelIsNull(string mediaTypeName)
+        public async Task ProfileControllerPostRefreshReturnsBadResultWhenModelIsNull(string mediaTypeName)
         {
             // Arrange
             RefreshJobProfileSegment refreshJobProfileSegmentModel = null;
@@ -44,15 +43,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             // Assert
             var statusResult = Assert.IsType<BadRequestResult>(result);
-
-            A.Equals((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerPostRefreshReturnsBadResultWhenModelIsInvalid(string mediaTypeName)
+        public async Task ProfileControllerPostRefreshReturnsBadResultWhenModelIsInvalid(string mediaTypeName)
         {
             // Arrange
             var refreshJobProfileSegmentModel = new RefreshJobProfileSegment();
@@ -65,8 +63,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             // Assert
             var statusResult = Assert.IsType<BadRequestObjectResult>(result);
-
-            A.Equals((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.BadRequest, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerProfileTests.cs
+++ b/DFC.App.JobProfile.UnitTests/ControllerTests/ProfileControllerTests/ProfileControllerProfileTests.cs
@@ -4,6 +4,7 @@ using FakeItEasy;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
@@ -13,7 +14,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
     {
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void JobProfileControllerProfileHtmlReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerProfileHtmlReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             var documentId = Guid.NewGuid();
@@ -33,14 +34,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             A.CallTo(() => FakeMapper.Map(A<JobProfileModel>.Ignored, A<BodyViewModel>.Ignored)).MustHaveHappenedOnceExactly();
 
             var viewResult = Assert.IsType<ViewResult>(result);
-            var model = Assert.IsAssignableFrom<BodyViewModel>(viewResult.ViewData.Model);
+            Assert.IsAssignableFrom<BodyViewModel>(viewResult.ViewData.Model);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void JobProfileControllerProfileJsonReturnsSuccess(string mediaTypeName)
+        public async Task JobProfileControllerProfileJsonReturnsSuccess(string mediaTypeName)
         {
             // Arrange
             var documentId = Guid.NewGuid();
@@ -62,38 +63,15 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
             var jsonResult = Assert.IsType<OkObjectResult>(result);
             var model = Assert.IsAssignableFrom<JobProfileModel>(jsonResult.Value);
 
-            A.Equals(model.DocumentId, documentId);
+            Assert.Equal(model.DocumentId, documentId);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(HtmlMediaTypes))]
-        public async void ProfileControllerDocumentHtmlReturnsNoContentWhenNoData(string mediaTypeName)
-        {
-            // Arrange
-            var documentId = Guid.NewGuid();
-            Data.Models.JobProfileModel expectedResult = null;
-            var controller = BuildProfileController(mediaTypeName);
-
-            A.CallTo(() => FakeJobProfileService.GetByIdAsync(A<Guid>.Ignored)).Returns(expectedResult);
-
-            // Act
-            var result = await controller.Profile(documentId).ConfigureAwait(false);
-
-            // Assert
-            A.CallTo(() => FakeJobProfileService.GetByIdAsync(A<Guid>.Ignored)).MustHaveHappenedOnceExactly();
-
-            var statusResult = Assert.IsType<NoContentResult>(result);
-
-            A.Equals((int)HttpStatusCode.NoContent, statusResult.StatusCode);
-
-            controller.Dispose();
-        }
-
-        [Theory]
         [MemberData(nameof(JsonMediaTypes))]
-        public async void ProfileControllerDocumentJsonReturnsNoContentWhenNoData(string mediaTypeName)
+        public async Task ProfileControllerDocumentHtmlAndJsonReturnsNoContentWhenNoData(string mediaTypeName)
         {
             // Arrange
             var documentId = Guid.NewGuid();
@@ -110,14 +88,14 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusResult = Assert.IsType<NoContentResult>(result);
 
-            A.Equals((int)HttpStatusCode.NoContent, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NoContent, statusResult.StatusCode);
 
             controller.Dispose();
         }
 
         [Theory]
         [MemberData(nameof(InvalidMediaTypes))]
-        public async void JobProfileControllerProfileReturnsNotAcceptable(string mediaTypeName)
+        public async Task JobProfileControllerProfileReturnsNotAcceptable(string mediaTypeName)
         {
             // Arrange
             var documentId = Guid.NewGuid();
@@ -138,7 +116,7 @@ namespace DFC.App.JobProfile.UnitTests.ControllerTests.ProfileControllerTests
 
             var statusResult = Assert.IsType<StatusCodeResult>(result);
 
-            A.Equals((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
+            Assert.Equal((int)HttpStatusCode.NotAcceptable, statusResult.StatusCode);
 
             controller.Dispose();
         }

--- a/DFC.App.JobProfile.UnitTests/DFC.App.JobProfile.UnitTests.csproj
+++ b/DFC.App.JobProfile.UnitTests/DFC.App.JobProfile.UnitTests.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile.UnitTests/DFC.App.JobProfile.UnitTests.csproj
+++ b/DFC.App.JobProfile.UnitTests/DFC.App.JobProfile.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectGuid>{7D61AF8F-0EDF-4F5B-B11C-5F9E53E089D3}</ProjectGuid>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>../UnitTests.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
@@ -13,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.4.1" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.JobProfile/AutoMapperProfiles/JobProfileModelProfile.cs
+++ b/DFC.App.JobProfile/AutoMapperProfiles/JobProfileModelProfile.cs
@@ -2,7 +2,6 @@
 using DFC.App.JobProfile.Data.Models;
 using DFC.App.JobProfile.ViewModels;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace DFC.App.JobProfile.AutoMapperProfiles
 {
@@ -18,110 +17,20 @@ namespace DFC.App.JobProfile.AutoMapperProfiles
 
             CreateMap<JobProfileModel, DocumentViewModel>()
                 .ForMember(d => d.Breadcrumb, s => s.Ignore())
+                .ForMember(d => d.Head, s => s.MapFrom(a => a))
+                .ForMember(d => d.Body, s => s.MapFrom(a => a))
                 .ForMember(d => d.Title, s => s.MapFrom(a => a.MetaTags.Title))
                 .ForMember(d => d.Description, s => s.MapFrom(a => a.MetaTags.Description))
-                .ForMember(d => d.Keywords, s => s.MapFrom(a => a.MetaTags.Keywords))
-                .ForMember(
-                    d => d.OverviewBannerSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.Overview)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.OverviewBannerSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.Overview)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-
-                .ForMember(
-                    d => d.HowToBecomeSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.HowToBecome)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.HowToBecomeSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.HowToBecome)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.WhatItTakesSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.WhatItTakes)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.WhatItTakesSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.WhatItTakes)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-
-                .ForMember(
-                    d => d.WhatYouWillDoSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.WhatYouWillDo)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.WhatYouWillDoSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.WhatYouWillDo)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-
-                .ForMember(
-                    d => d.CareerPathSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.CareerPathsAndProgression)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.CareerPathSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.CareerPathsAndProgression)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-
-                .ForMember(
-                    d => d.CurrentOpportunitiesSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.CurrentOpportunities)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.CurrentOpportunitiesSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.CurrentOpportunities)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-
-                .ForMember(
-                    d => d.RelatedCareersSegmentMarkup,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.RelatedCareers)
-                            .Select(seg => seg.Markup)
-                            .SingleOrDefault()))
-                .ForMember(
-                    d => d.RelatedCareersSegmentUpdated,
-                    o => o.MapFrom(s => s.Segments
-                            .Where(m => m.Segment == Data.JobProfileSegment.RelatedCareers)
-                            .Select(seg => seg.RefreshedAt)
-                            .SingleOrDefault()))
-            ;
+                .ForMember(d => d.Keywords, s => s.MapFrom(a => a.MetaTags.Keywords));
 
             CreateMap<JobProfileModel, HeadViewModel>()
                 .ForMember(d => d.CanonicalUrl, s => s.Ignore())
                 .ForMember(d => d.CssLink, s => s.Ignore())
                 .ForMember(d => d.Title, s => s.MapFrom(a => a.MetaTags.Title + " | Explore careers | National Careers Service"))
                 .ForMember(d => d.Description, s => s.MapFrom(a => a.MetaTags.Description))
-                .ForMember(d => d.Keywords, s => s.MapFrom(a => a.MetaTags.Keywords))
-                ;
+                .ForMember(d => d.Keywords, s => s.MapFrom(a => a.MetaTags.Keywords));
 
-            CreateMap<JobProfileModel, IndexDocumentViewModel>()
-                ;
+            CreateMap<JobProfileModel, IndexDocumentViewModel>();
         }
     }
 }

--- a/DFC.App.JobProfile/DFC.App.JobProfile.csproj
+++ b/DFC.App.JobProfile/DFC.App.JobProfile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <Content Remove="appsettings-template.json" />
-    <Content Remove="appsettings.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,16 +27,14 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="CorrelationId" Version="2.1.0" />
-    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.6" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="DFC.Logger.AppInsights" Version="1.0.7" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.96" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DFC.App.JobProfile/DFC.App.JobProfile.csproj
+++ b/DFC.App.JobProfile/DFC.App.JobProfile.csproj
@@ -44,7 +44,6 @@
 
 
   <ItemGroup>
-    <None Include="appsettings.json" />
     <None Include="appsettings-template.json" />
   </ItemGroup>
 

--- a/DFC.App.JobProfile/Exceptions/InvalidProfileException.cs
+++ b/DFC.App.JobProfile/Exceptions/InvalidProfileException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+namespace DFC.App.JobProfile.Exceptions
+{
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public class InvalidProfileException : Exception
+    {
+        public InvalidProfileException() : base()
+        {
+        }
+
+        public InvalidProfileException(string message) : base(message)
+        {
+        }
+
+        public InvalidProfileException(string message, Exception exception) : base(message, exception)
+        {
+        }
+
+        protected InvalidProfileException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/DFC.App.JobProfile/Extensions/ControllerExtensions.cs
+++ b/DFC.App.JobProfile/Extensions/ControllerExtensions.cs
@@ -18,16 +18,16 @@ namespace DFC.App.JobProfile.Extensions
 
             if (controller.Request.Headers.Keys.Contains(HeaderNames.Accept))
             {
-                var acceptHeaders = controller.Request.Headers[HeaderNames.Accept].ToString().ToLowerInvariant().Split(';');
+                var acceptHeaders = controller.Request.Headers[HeaderNames.Accept].ToString().ToUpperInvariant().Split(';');
                 foreach (var acceptHeader in acceptHeaders)
                 {
                     var items = acceptHeader.Split(',');
-                    if (items.Contains(MediaTypeNames.Application.Json))
+                    if (items.Contains(MediaTypeNames.Application.Json.ToUpperInvariant()))
                     {
                         return controller.Ok(dataModel ?? viewModel);
                     }
 
-                    if (items.Contains(MediaTypeNames.Text.Html) || items.Contains("*/*"))
+                    if (items.Contains(MediaTypeNames.Text.Html.ToUpperInvariant()) || items.Contains("*/*"))
                     {
                         return controller.View(viewModel);
                     }

--- a/DFC.App.JobProfile/Extensions/ServiceCollectionExtensions.cs
+++ b/DFC.App.JobProfile/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using DFC.App.JobProfile.ClientHandlers;
 using DFC.App.JobProfile.Data.HttpClientPolicies;
 using DFC.App.JobProfile.HttpClientPolicies;
-using DFC.Logger.AppInsights.Constants;
-using DFC.Logger.AppInsights.Contracts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/DFC.App.JobProfile/Extensions/ServiceCollectionExtensions.cs
+++ b/DFC.App.JobProfile/Extensions/ServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ namespace DFC.App.JobProfile.Extensions
             string keyPrefix,
             PolicyOptions policyOptions)
         {
-            policyRegistry.Add(
+            policyRegistry?.Add(
                 $"{keyPrefix}_{nameof(PolicyOptions.HttpRetry)}",
                 HttpPolicyExtensions
                     .HandleTransientHttpError()
@@ -32,7 +32,7 @@ namespace DFC.App.JobProfile.Extensions
                         policyOptions.HttpRetry.Count,
                         retryAttempt => TimeSpan.FromSeconds(Math.Pow(policyOptions.HttpRetry.BackoffPower, retryAttempt))));
 
-            policyRegistry.Add(
+            policyRegistry?.Add(
                 $"{keyPrefix}_{nameof(PolicyOptions.HttpCircuitBreaker)}",
                 HttpPolicyExtensions
                     .HandleTransientHttpError()
@@ -53,7 +53,7 @@ namespace DFC.App.JobProfile.Extensions
                     where TImplementation : class, TClient
                     where TClientOptions : SegmentClientOptions, new() =>
                     services
-                        .Configure<TClientOptions>(configuration.GetSection(configurationSectionName))
+                        .Configure<TClientOptions>(configuration?.GetSection(configurationSectionName))
                         .AddHttpClient<TClient, TImplementation>()
                         .ConfigureHttpClient((sp, options) =>
                         {
@@ -65,12 +65,9 @@ namespace DFC.App.JobProfile.Extensions
                             options.DefaultRequestHeaders.Clear();
                             options.DefaultRequestHeaders.Add(HeaderNames.Accept, MediaTypeNames.Application.Json);
                         })
-                        .ConfigurePrimaryHttpMessageHandler(() =>
+                        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                         {
-                            return new HttpClientHandler()
-                            {
-                                AllowAutoRedirect = false,
-                            };
+                            AllowAutoRedirect = false,
                         })
                         .AddPolicyHandlerFromRegistry($"{configurationSectionName}_{retryPolicyName}")
                         .AddPolicyHandlerFromRegistry($"{configurationSectionName}_{circuitBreakerPolicyName}")

--- a/DFC.App.JobProfile/Startup.cs
+++ b/DFC.App.JobProfile/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
@@ -38,26 +39,8 @@ namespace DFC.App.JobProfile
             this.configuration = configuration;
         }
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddApplicationInsightsTelemetry();
-            services.AddAutoMapper(typeof(Startup).Assembly);
-            services.AddCorrelationId();
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-
-            AddApplicationSpecificDependencyInjectionConfiguration(services);
-        }
-
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IMapper mapper)
+        public static void Configure(IApplicationBuilder app, IWebHostEnvironment env, IMapper mapper)
         {
             app.UseCorrelationId(new CorrelationIdOptions
             {
@@ -81,27 +64,47 @@ namespace DFC.App.JobProfile
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();
-            app.UseMvc(routes =>
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
             {
                 // add the site map route
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "Sitemap",
-                    template: "Sitemap.xml",
+                    pattern: "Sitemap.xml",
                     defaults: new { controller = "Sitemap", action = "Sitemap" });
 
                 // add the robots.txt route
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "Robots",
-                    template: "Robots.txt",
+                    pattern: "Robots.txt",
                     defaults: new { controller = "Robot", action = "Robot" });
 
                 // add the default route as health/ping
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "default",
-                    template: "{controller=Health}/{action=Ping}");
+                    pattern: "{controller=Health}/{action=Ping}");
             });
 
             mapper?.ConfigurationProvider.AssertConfigurationIsValid();
+        }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddApplicationInsightsTelemetry();
+            services.AddAutoMapper(typeof(Startup).Assembly);
+            services.AddCorrelationId();
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
+            AddApplicationSpecificDependencyInjectionConfiguration(services);
         }
 
         private void AddApplicationSpecificDependencyInjectionConfiguration(IServiceCollection services)
@@ -114,7 +117,7 @@ namespace DFC.App.JobProfile
             services.AddSingleton<ICosmosRepository<JobProfileModel>, CosmosRepository<JobProfileModel>>();
 
             services.AddScoped<IJobProfileService, JobProfileService>();
-            services.AddScoped<Data.Contracts.ISegmentService, SegmentService>();
+            services.AddScoped<ISegmentService, SegmentService>();
             services.AddTransient<CorrelationIdDelegatingHandler>();
             services.AddDFCLogging(configuration["ApplicationInsights:InstrumentationKey"]);
 

--- a/DFC.App.JobProfile/ViewModels/DocumentViewModel.cs
+++ b/DFC.App.JobProfile/ViewModels/DocumentViewModel.cs
@@ -1,12 +1,15 @@
-﻿using Microsoft.AspNetCore.Html;
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace DFC.App.JobProfile.ViewModels
 {
     public class DocumentViewModel
     {
+        public HeadViewModel Head { get; set; }
+
         public BreadcrumbViewModel Breadcrumb { get; set; }
+
+        public BodyViewModel Body { get; set; }
 
         [Display(Name = "Document Id")]
         public Guid? DocumentId { get; set; }
@@ -26,51 +29,12 @@ namespace DFC.App.JobProfile.ViewModels
 
         public string Keywords { get; set; }
 
+        [Display(Name = "Last Updated")]
         public DateTime LastReviewed { get; set; }
+
+        public long SequenceNumber { get; set; }
 
         [Display(Name = "Alternative Names")]
         public string[] AlternativeNames { get; set; }
-
-        [Display(Name = "Overview Banner Markup")]
-        public HtmlString OverviewBannerSegmentMarkup { get; set; }
-
-        [Display(Name = "Overview Banner Updated")]
-        public DateTime OverviewBannerSegmentUpdated { get; set; }
-
-        [Display(Name = "Current Opportunities Markup")]
-        public HtmlString CurrentOpportunitiesSegmentMarkup { get; set; }
-
-        [Display(Name = "Current Opportunities Updated")]
-        public DateTime CurrentOpportunitiesSegmentUpdated { get; set; }
-
-        [Display(Name = "Related Careers Markup")]
-        public HtmlString RelatedCareersSegmentMarkup { get; set; }
-
-        [Display(Name = "Related Careers Updated")]
-        public DateTime RelatedCareersSegmentUpdated { get; set; }
-
-        [Display(Name = "Career Path Markup")]
-        public HtmlString CareerPathSegmentMarkup { get; set; }
-
-        [Display(Name = "Career Path Updated")]
-        public DateTime CareerPathSegmentUpdated { get; set; }
-
-        [Display(Name = "How To Become Markup")]
-        public HtmlString HowToBecomeSegmentMarkup { get; set; }
-
-        [Display(Name = "How To Become Updated")]
-        public DateTime HowToBecomeSegmentUpdated { get; set; }
-
-        [Display(Name = "What It Takes Markup")]
-        public HtmlString WhatItTakesSegmentMarkup { get; set; }
-
-        [Display(Name = "What It Takes Updated")]
-        public DateTime WhatItTakesSegmentUpdated { get; set; }
-
-        [Display(Name = "What You Will Do Markup")]
-        public HtmlString WhatYouWillDoSegmentMarkup { get; set; }
-
-        [Display(Name = "What You Will Do Updated")]
-        public DateTime WhatYouWillDoSegmentUpdated { get; set; }
     }
 }

--- a/DFC.App.JobProfile/Views/Profile/Document.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/Document.cshtml
@@ -9,16 +9,7 @@
 
         <title>@ViewData["Title"]</title>
     }
-
-    @if (!string.IsNullOrWhiteSpace(Model.Description))
-    {
-        <meta name="description" Markup="@Model.Description">
-    }
-
-    @if (!string.IsNullOrWhiteSpace(Model.Description))
-    {
-        <meta name="keywords" Markup="@Model.Keywords">
-    }
+    <partial name="_Head" model=@Model.Head />
 </head>
 <body>
     <div>
@@ -36,150 +27,24 @@
             <dd class="col-sm-10">
                 @Html.DisplayFor(model => model.CanonicalName)
             </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.Title)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Title)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.BreadcrumbTitle)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.BreadcrumbTitle)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.IncludeInSitemap)
-            </dt>
-
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.IncludeInSitemap)
-            </dd>
-
             <dt class="col-sm-2">
                 @Html.DisplayNameFor(model => model.LastReviewed)
             </dt>
             <dd class="col-sm-10">
                 @Html.DisplayFor(model => model.LastReviewed)
             </dd>
-
             <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.OverviewBannerSegmentMarkup)
+                @Html.DisplayNameFor(model => model.SequenceNumber)
             </dt>
             <dd class="col-sm-10">
-                @Html.Raw(Model.OverviewBannerSegmentMarkup)
+                @Html.DisplayFor(model => model.SequenceNumber)
             </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.OverviewBannerSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.OverviewBannerSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.CurrentOpportunitiesSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.CurrentOpportunitiesSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.CurrentOpportunitiesSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.CurrentOpportunitiesSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.RelatedCareersSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.RelatedCareersSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.RelatedCareersSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.RelatedCareersSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.CareerPathSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.CareerPathSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.CareerPathSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.CareerPathSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.HowToBecomeSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.HowToBecomeSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.HowToBecomeSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.HowToBecomeSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.WhatItTakesSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.WhatItTakesSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.WhatItTakesSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.WhatItTakesSegmentUpdated)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.WhatYouWillDoSegmentMarkup)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.Raw(Model.WhatYouWillDoSegmentMarkup)
-            </dd>
-
-            <dt class="col-sm-2">
-                @Html.DisplayNameFor(model => model.WhatYouWillDoSegmentUpdated)
-            </dt>
-            <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.WhatYouWillDoSegmentUpdated)
-            </dd>
-
-            @if (Model.AlternativeNames?.Count() > 0)
-            {
-                <dt class="col-sm-2">
-                    @Html.DisplayNameFor(model => model.AlternativeNames)
-                </dt>
-                <dd class="col-sm-10">
-                    <ol>
-                        @foreach (var alternativeName in Model.AlternativeNames)
-                        {
-                            <li><a href="/profile/@alternativeName">@alternativeName</a></li>
-                        }
-                    </ol>
-                </dd>
-            }
         </dl>
     </div>
+
+    <partial name="_Hero" model=@Model.Body.Segments.SingleOrDefault(s => s.Segment == DFC.App.JobProfile.Data.JobProfileSegment.Overview)?.Markup />
+    <partial name="_BodyContent" model=@Model.Body />
+
     <div>
         <a asp-action="Index">Back to List</a>
     </div>

--- a/DFC.App.JobProfile/Views/Profile/Head.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/Head.cshtml
@@ -1,28 +1,3 @@
 ﻿@model HeadViewModel
 
-@if (!string.IsNullOrWhiteSpace(Model.Title))
-{
-    ViewData["Title"] = Model.Title;
-
-    <title>@ViewData["Title"]</title>
-}
-
-@if (!string.IsNullOrWhiteSpace(Model.CanonicalUrl))
-{
-    <link rel="canonical" href="@Model.CanonicalUrl">
-}
-
-@if (!string.IsNullOrWhiteSpace(Model.Description))
-{
-    <meta name="description" content="@Model.Description">
-}
-
-@if (!string.IsNullOrWhiteSpace(Model.Keywords))
-{
-    <meta name="keywords" content="@Model.Keywords">
-}
-
-@if (!string.IsNullOrWhiteSpace(Model.CssLink))
-{
-    <link href="@Model.CssLink" rel="stylesheet" type="text/css" />
-}
+<partial name="_Head" model=Model />

--- a/DFC.App.JobProfile/Views/Profile/Hero.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/Hero.cshtml
@@ -1,3 +1,3 @@
 ﻿@model HeroViewModel
 
-<partial name="_OverviewBannerSegment" model=@Model.Segments.SingleOrDefault(s => s.Segment == DFC.App.JobProfile.Data.JobProfileSegment.Overview)?.Markup />
+<partial name="_Hero" model=@Model.Segments.SingleOrDefault(s => s.Segment == DFC.App.JobProfile.Data.JobProfileSegment.Overview)?.Markup />

--- a/DFC.App.JobProfile/Views/Profile/Index.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/Index.cshtml
@@ -8,6 +8,7 @@
 <body>
     @if (Model.Documents?.Count() > 0)
     {
+        <h2>Job Profiles Summary List</h2>
         <ul>
             @foreach (var document in Model.Documents)
             {

--- a/DFC.App.JobProfile/Views/Profile/_ContactUsSnippet.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_ContactUsSnippet.cshtml
@@ -1,7 +1,7 @@
 ﻿<div>
     <h3 class="govuk-heading-m">Get help using this service</h3>
     <p class="govuk-body govuk-!-margin-bottom-0">
-        <span class="govuk-body govuk-!-font-weight-bold">Call&nbsp;</span>0800 100 900 or <a style="white-space:nowrap;" href="/webchat/chat/" target="'_blank'">use webchat</a>
+        <span class="govuk-body govuk-!-font-weight-bold">Call&nbsp;</span>0800 100 900 or <a class="dfc-no-wrap" href="/webchat/chat/" target="'_blank'">use webchat</a>
     </p>
     <p class="govuk-caption-m govuk-!-font-size-16">8am to 10pm, 7 days a week</p>
     <p>More ways to <a href="/contact-us">contact us</a></p>

--- a/DFC.App.JobProfile/Views/Profile/_Head.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_Head.cshtml
@@ -1,0 +1,28 @@
+﻿@model HeadViewModel
+
+@if (!string.IsNullOrWhiteSpace(Model.Title))
+{
+    ViewData["Title"] = Model.Title;
+
+    <title>@ViewData["Title"]</title>
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.CanonicalUrl))
+{
+    <link rel="canonical" href="@Model.CanonicalUrl">
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.Description))
+{
+    <meta name="description" content="@Model.Description">
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.Keywords))
+{
+    <meta name="keywords" content="@Model.Keywords">
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.CssLink))
+{
+    <link href="@Model.CssLink" rel="stylesheet" type="text/css" />
+}

--- a/DFC.App.JobProfile/Views/Profile/_Hero.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_Hero.cshtml
@@ -1,0 +1,3 @@
+﻿@model HtmlString
+
+<partial name="_OverviewBannerSegment" model=@Model />

--- a/DFC.App.JobProfile/Views/Profile/_Search.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_Search.cshtml
@@ -1,19 +1,20 @@
-﻿@model string
+﻿
+@model string
 
-<div class="job-profile-sidebar">
-    <h3 id="job-profile-search" class="govuk-heading-m">Not what you're looking for?</h3>
-    <div class="job-profile-search">
-        <h4>Search further careers</h4>
-        <form action="/search-results" class="js-live-search-form site-search ui-front" id="job-profile-search-box" method="get">
-            <div class="job-profile-search-content">
-                <label for="search-main"> Enter a job title</label>
-                <div class="search-input-wrapper">
-                    <input class="govuk-input search-input js-search-focus js-autocomplete ui-autocomplete-input" data-autocomplete-fuzzysearch="True" data-autocomplete-maxlength="7" data-autocomplete-maxnumberdisplyed="5" data-autocomplete-minlength="2" data-autocomplete-source="/searchautocomplete" id="search-main" name="SearchTerm" type="search" value="" autocomplete="off">
+    <div class="job-profile-sidebar">
+        <h3 id="job-profile-search" class="govuk-heading-m">Not what you're looking for?</h3>
+        <div class="job-profile-search">
+            <h4>Search further careers</h4>
+            <form action="/search-results" class="js-live-search-form site-search ui-front" id="job-profile-search-box" method="get">
+                <div class="job-profile-search-content">
+                    <label class="input-label" for="search-main"> Enter a job title</label>
+                    <div class="search-input-wrapper">
+                        <input class="govuk-input search-input js-search-focus js-autocomplete ui-autocomplete-input" data-autocomplete-fuzzysearch="True" data-autocomplete-maxlength="7" data-autocomplete-maxnumberdisplyed="5" data-autocomplete-minlength="2" data-autocomplete-source="/searchautocomplete" id="search-main" name="SearchTerm" type="search" value="" autocomplete="off">
+                    </div>
+                    <button class="submit" type="submit" value="Search">Search</button>
                 </div>
-                <button class="submit" type="submit" value="Search">Search</button>
-            </div>
-            <input id="JobProfileUrl" name="JobProfileUrl" type="hidden" value="@Model">
-            <ul id="ui-id-1" tabindex="0" class="ui-menu ui-widget ui-widget-content ui-autocomplete ui-front" style="display: none;"></ul>
-        </form>
+                <input id="JobProfileUrl" name="JobProfileUrl" type="hidden" value="@Model">
+            </form>
+            
+        </div>
     </div>
-</div>

--- a/DFC.App.JobProfile/appsettings-template.json
+++ b/DFC.App.JobProfile/appsettings-template.json
@@ -36,30 +36,51 @@
   },
   "CareerPathSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost/",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>Career path - Unavailable</H2>",
+    "Name": "DFC.App.CareerPath"
   },
   "CurrentOpportunitiesSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>Current opportunities - Unavailable</H2>",
+    "Name": "DFC.App.JobProfile.CurrentOpportunities"
   },
   "HowToBecomeSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>How to become - Unavailable</H2>",
+    "Name": "DFC.App.JobProfiles.HowToBecome"
   },
   "OverviewBannerSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>Overview banner - Unavailable</H2>",
+    "Name": "DFC.App.JobProfileOverview"
   },
   "RelatedCareersSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>Related careers - Unavailable</H2>",
+    "Name": "DFC.App.RelatedCareers"
   },
   "WhatItTakesSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>What it takes - Unavailable</H2>",
+    "Name": "DFC.App.JobProfileSkills"
   },
   "WhatYouWillDoSegmentClientOptions": {
     "Timeout": "00:00:10",
-    "BaseAddress": "https://localhost"
+    "BaseAddress": "https://localhost",
+    "Endpoint": "segment/{0}/contents",
+    "OfflineHtml": "<H2>What you will do - Unavailable</H2>",
+    "Name": "DFC.App.JobProfileTasks"
   }
 }

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -58,6 +58,9 @@
         },
         "surveyUrl": {
             "value": "__surveyFeedbackUrl__"
+        },
+        "enableAlerts": {
+            "value": __EnableAzureMonitorAlerting__
         }
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -86,6 +86,12 @@
             "metadata": {
                 "description": "URL of customer survey"
             }
+        },
+        "enableAlerts": {
+            "type": "bool",
+            "metadata": {
+                "description": "Enable or disable alerting"
+            }
         }
     },
     "variables": {
@@ -110,7 +116,8 @@
         "functionAppName": "[concat(variables('ResourcePrefix'), '-fa')]",
         "functionAppInsightsName": "[concat(variables('functionAppName'), '-ai')]",
         "cmsSubscriptionName": "job-profile-metadata",
-        "refreshSubscriptionName": "job-profile-segment-refresh"
+        "refreshSubscriptionName": "job-profile-segment-refresh",
+        "ActionGroupName": "[concat('dfc-', replace(tolower(parameters('Environment')), '-draft', ''), '-app-sharedresources-actgrp')]"
     },
     "resources": [
         {
@@ -173,7 +180,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[concat(variables('buildingBlocksDfcBaseUrl'), 'app-service.json')]",
+                    "uri": "[concat(variables('buildingBlocksDfcBaseUrl'), 'app-service-staging.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -188,9 +195,6 @@
                     },
                     "appServiceType": {
                         "value": "app"
-                    },
-                    "deployStagingSlot": {
-                        "value": false
                     },
                     "appServiceAppSettings": {
                         "value": [
@@ -260,7 +264,7 @@
                             },
                             {
                                 "name": "OverviewBannerSegmentClientOptions__OfflineHtml",
-                                "value": "<header class=\"job-profile-hero\"><div class=\"govuk-width-container\"><div class=\"govuk-grid-row\"><div class=\"govuk-grid-column-two-thirds\"><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></div></div></div></header>"
+                                "value": ""
                             },
                             {
                                 "name": "CurrentOpportunitiesSegmentClientOptions__Timeout",
@@ -308,7 +312,7 @@
                             },
                             {
                                 "name": "HowToBecomeSegmentClientOptions__OfflineHtml",
-                                "value": "<section id=\"HowToBecome\"><h2 class=\"job-profile-heading\">How to become</h2><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
+                                "value": ""
                             },
                             {
                                 "name": "RelatedCareersSegmentClientOptions__Timeout",
@@ -340,7 +344,7 @@
                             },
                             {
                                 "name": "WhatItTakesSegmentClientOptions__OfflineHtml",
-                                "value": "<section id=\"WhatItTakes\"><h2 class=\"job-profile-heading\">What it takes</h2><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
+                                "value": ""
                             },
                             {
                                 "name": "WhatYouWillDoSegmentClientOptions__Timeout",
@@ -422,9 +426,9 @@
                     },
                     "appServiceAppSettings": {
                         "value": [
-                             {
+                            {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",
-                                "value": "~2"
+                                "value": "~3"
                             },
                             {
                                 "name": "MSDEPLOY_RENAME_LOCKED_FILES",
@@ -557,62 +561,6 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[parameters('refreshTopicName')]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('appSharedResourceGroup')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "serviceBusNamespaceName": {
-                        "value": "[parameters('appSharedServiceBusName')]"
-                    },
-                    "serviceBusTopicName": {
-                        "value": "[parameters('refreshTopicName')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2017-05-10",
-            "name": "[concat('monitor-',parameters('refreshTopicName'))]",
-            "type": "Microsoft.Resources/deployments",
-            "resourceGroup": "[parameters('appSharedResourceGroup')]",
-            "condition" : "[not(variables('productionEnvironment'))]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'ServiceBus/servicebus-topic-authrule.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "authorizationRuleName": {
-                        "value": "[concat('monitor-',parameters('refreshTopicName'))]"
-                    },
-                    "topicName": {
-                        "value": "[parameters('refreshTopicName')]"
-                    },
-                    "rights": {
-                        "value": [
-                            "manage",
-                            "send",
-                            "listen"
-                        ]
-                    },
-                    "servicebusName": {
-                        "value": "[parameters('appSharedServiceBusName')]"
-                    }
-                }
-            },
-            "dependsOn": [
-                "[parameters('refreshTopicName')]"
-            ]
-        },
-        {
-            "apiVersion": "2017-05-10",
             "name": "[variables('refreshSubscriptionName')]",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('appSharedResourceGroup')]",
@@ -633,11 +581,173 @@
                         "value": "[variables('refreshSubscriptionName')]"
                     }
                 }
-            },
-            "dependsOn": [
-                "[parameters('refreshTopicName')]"
-            ]
+            }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('webAppInsightsName'), '-metric-exceptions')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "alertName": {
+                      "value": "[concat(variables('webAppInsightsName'), '-metric-exceptions')]"
+                  },
+                  "alertSeverity": {
+                      "value": 3
+                  },
+                  "metricName": {
+                      "value": "exceptions/count"
+                  },
+                  "operator": {
+                      "value": "GreaterThan"
+                  },
+                  "threshold": {
+                      "value": "0"
+                  },
+                  "aggregation": {
+                      "value": "Count"
+                  },
+                  "windowSize": {
+                      "value": "PT5M"
+                  },
+                  "evaluationFrequency": {
+                      "value": "PT1M"
+                  },
+                  "actionGroupName": {
+                      "value": "[variables('ActionGroupName')]"
+                  },
+                  "actionGroupResourceGroup": {
+                      "value": "[parameters('appSharedResourceGroup')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('webAppInsightsName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('webAppInsightsName'), '-failure-anomaly-v2')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "alertName": {
+                      "value": "[concat(variables('webAppInsightsName'), '-failure-anomaly-v2')]"
+                  },
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('webAppInsightsName'))]"
+                  },
+                  "actionGroupId": {
+                      "value": "[resourceId(parameters('appSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('functionAppInsightsName'), '-metric-exceptions')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('webAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "alertName": {
+                      "value": "[concat(variables('functionAppInsightsName'), '-metric-exceptions')]"
+                  },
+                  "alertSeverity": {
+                      "value": 3
+                  },
+                  "metricName": {
+                      "value": "exceptions/count"
+                  },
+                  "operator": {
+                      "value": "GreaterThan"
+                  },
+                  "threshold": {
+                      "value": "0"
+                  },
+                  "aggregation": {
+                      "value": "Count"
+                  },
+                  "windowSize": {
+                      "value": "PT5M"
+                  },
+                  "evaluationFrequency": {
+                      "value": "PT1M"
+                  },
+                  "actionGroupName": {
+                      "value": "[variables('ActionGroupName')]"
+                  },
+                  "actionGroupResourceGroup": {
+                      "value": "[parameters('appSharedResourceGroup')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('functionAppInsightsName'))]"
+                  }
+              }
+          }
+        },
+        {
+          "apiVersion": "2019-05-01",
+          "name": "[concat(variables('functionAppInsightsName'), '-failure-anomaly-v2')]",
+          "type": "Microsoft.Resources/deployments",
+          "dependsOn": [
+              "[variables('functionAppInsightsName')]"
+          ],
+          "properties": {
+              "mode": "Incremental",
+              "templateLink": {
+                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
+                  "contentVersion": "1.0.0.0"
+              },
+              "parameters": {
+                  "alertName": {
+                      "value": "[concat(variables('functionAppInsightsName'), '-failure-anomaly-v2')]"
+                  },
+                  "enabled": {
+                      "value": "[parameters('enableAlerts')]"
+                  },
+                  "resourceId": {
+                      "value": "[resourceId('Microsoft.Insights/Components', variables('functionAppInsightsName'))]"
+                  },
+                  "actionGroupId": {
+                      "value": "[resourceId(parameters('appSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
+                  }
+              }
+          }
         }
     ],
-        "outputs": {}
+    "outputs": {
     }
+}

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -197,180 +197,208 @@
                         "value": "app"
                     },
                     "appServiceAppSettings": {
-                        "value": [
-                            {
-                                "name": "MSDEPLOY_RENAME_LOCKED_FILES",
-                                "value": "1"
-                            },
-                            {
-                                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                                "value": "[reference(variables('webAppInsightsName')).outputs.InstrumentationKey.value]"
-                            },
-                            {
-                                "name": "AzureWebJobsStorage",
-                                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('appSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('appSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
-                            },
-                            {
-                                "name": "BrandingAssets__AppCssFilePath",
-                                "value": "[parameters('brandingAssetsAppCssFilePath')]"
-                            },
-                            {
-                                "name": "Configuration__CosmosDbConnections__JobProfile__AccessKey",
-                                "value": "[parameters('cosmosDbKey')]"
-                            },
-                            {
-                                "name": "Configuration__CosmosDbConnections__JobProfile__EndpointUrl",
-                                "value": "[variables('cosmosDbEndpoint')]"
-                            },
-                            {
-                                "name": "Configuration__CosmosDbConnections__JobProfile__DatabaseId",
-                                "value": "[variables('cosmosDbDatabaseName')]"
-                            },
-                            {
-                                "name": "Configuration__CosmosDbConnections__JobProfile__CollectionId",
-                                "value": "[parameters('cosmosDbCollectionName')]"
-                            },
-                            {
-                                "name": "Configuration__CosmosDbConnections__JobProfile__PartitionKey",
-                                "value": "[variables('cosmosDbCollectionPartitionKey')]"
-                            },
-                            {
-                                "name": "Policies__HttpCircuitBreaker__DurationOfBreak",
-                                "value": "00:01:00"
-                            },
-                            {
-                                "name": "Policies__HttpCircuitBreaker__ExceptionsAllowedBeforeBreaking",
-                                "value": 3
-                            },
-                            {
-                                "name": "Policies__HttpRetry__BackoffPower",
-                                "value": 2
-                            },
-                            {
-                                "name": "Policies__HttpRetry__Count",
-                                "value": 3
-                            },
-                            {
-                                "name": "OverviewBannerSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "OverviewBannerSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlJobprofileOverviewApp')]"
-                            },
-                            {
-                                "name": "OverviewBannerSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "OverviewBannerSegmentClientOptions__OfflineHtml",
-                                "value": ""
-                            },
-                            {
-                                "name": "CurrentOpportunitiesSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "CurrentOpportunitiesSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlJobprofileCurrentopportunitiesApp')]"
-                            },
-                            {
-                                "name": "CurrentOpportunitiesSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "CurrentOpportunitiesSegmentClientOptions__OfflineHtml",
-                                "value": "<section id=\"CurrentOpportunities\"> <h2 class=\"job-profile-heading\">Current opportunities</h2> <div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
-                            },
-                            {
-                                "name": "CareerPathSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "CareerPathSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlCareerpathApp')]"
-                            },
-                            {
-                                "name": "CareerPathSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "CareerPathSegmentClientOptions__OfflineHtml",
-                                "value": "<section id=\"CareerPathAndProgression\"> <h2 class=\"job-profile-heading\">Career path and progression</h2> <div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
-                            },
-                            {
-                                "name": "HowToBecomeSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "HowToBecomeSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlJobprofileHowtobecomeApp')]"
-                            },
-                            {
-                                "name": "HowToBecomeSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "HowToBecomeSegmentClientOptions__OfflineHtml",
-                                "value": ""
-                            },
-                            {
-                                "name": "RelatedCareersSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "RelatedCareersSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlRelatedcareersApp')]"
-                            },
-                            {
-                                "name": "RelatedCareersSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "RelatedCareersSegmentClientOptions__OfflineHtml",
-                                "value": "<div class=\"job-profile-related\"> <h3 class=\"govuk-heading-m\">Related careers</h3><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></div>"
-                            },
-                            {
-                                "name": "WhatItTakesSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "WhatItTakesSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlJobprofileSkillsApp')]"
-                            },
-                            {
-                                "name": "WhatItTakesSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "WhatItTakesSegmentClientOptions__OfflineHtml",
-                                "value": ""
-                            },
-                            {
-                                "name": "WhatYouWillDoSegmentClientOptions__Timeout",
-                                "value": "00:00:10"
-                            },
-                            {
-                                "name": "WhatYouWillDoSegmentClientOptions__BaseAddress",
-                                "value": "[variables('urlJobprofileTasksApp')]"
-                            },
-                            {
-                                "name": "WhatYouWillDoSegmentClientOptions__Endpoint",
-                                "value": "segment/{0}/contents"
-                            },
-                            {
-                                "name": "WhatYouWillDoSegmentClientOptions__OfflineHtml",
-                                "value": "<section id=\"WhatYouWillDo\"><h2 class=\"job-profile-heading\">What you'll do</h2><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
-                            },
-                            {
-                                "name": "FeedbackLinks__SmartSurveyJP",
-                                "value": "[parameters('surveyUrl')]"
-                            },
-                            {
-                                "name": "Logging__ApplicationInsights__LogLevel__Default",
-                                "value": "Information"
-                            }
-                        ]
+                      "value": [
+                        {
+                          "name": "MSDEPLOY_RENAME_LOCKED_FILES",
+                          "value": "1"
+                        },
+                        {
+                          "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                          "value": "[reference(variables('webAppInsightsName')).outputs.InstrumentationKey.value]"
+                        },
+                        {
+                          "name": "AzureWebJobsStorage",
+                          "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('appSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('appSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+                        },
+                        {
+                          "name": "BrandingAssets__AppCssFilePath",
+                          "value": "[parameters('brandingAssetsAppCssFilePath')]"
+                        },
+                        {
+                          "name": "Configuration__CosmosDbConnections__JobProfile__AccessKey",
+                          "value": "[parameters('cosmosDbKey')]"
+                        },
+                        {
+                          "name": "Configuration__CosmosDbConnections__JobProfile__EndpointUrl",
+                          "value": "[variables('cosmosDbEndpoint')]"
+                        },
+                        {
+                          "name": "Configuration__CosmosDbConnections__JobProfile__DatabaseId",
+                          "value": "[variables('cosmosDbDatabaseName')]"
+                        },
+                        {
+                          "name": "Configuration__CosmosDbConnections__JobProfile__CollectionId",
+                          "value": "[parameters('cosmosDbCollectionName')]"
+                        },
+                        {
+                          "name": "Configuration__CosmosDbConnections__JobProfile__PartitionKey",
+                          "value": "[variables('cosmosDbCollectionPartitionKey')]"
+                        },
+                        {
+                          "name": "Policies__HttpCircuitBreaker__DurationOfBreak",
+                          "value": "00:01:00"
+                        },
+                        {
+                          "name": "Policies__HttpCircuitBreaker__ExceptionsAllowedBeforeBreaking",
+                          "value": 3
+                        },
+                        {
+                          "name": "Policies__HttpRetry__BackoffPower",
+                          "value": 2
+                        },
+                        {
+                          "name": "Policies__HttpRetry__Count",
+                          "value": 3
+                        },
+                        {
+                          "name": "OverviewBannerSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "OverviewBannerSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlJobprofileOverviewApp')]"
+                        },
+                        {
+                          "name": "OverviewBannerSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "OverviewBannerSegmentClientOptions__OfflineHtml",
+                          "value": ""
+                        },
+                        {
+                          "name": "OverviewBannerSegmentClientOptions__Name",
+                          "value": "DFC.App.JobProfileOverview"
+                        },
+                        {
+                          "name": "CurrentOpportunitiesSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "CurrentOpportunitiesSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlJobprofileCurrentopportunitiesApp')]"
+                        },
+                        {
+                          "name": "CurrentOpportunitiesSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "CurrentOpportunitiesSegmentClientOptions__OfflineHtml",
+                          "value": "<section id=\"CurrentOpportunities\"> <h2 class=\"job-profile-heading\">Current opportunities</h2> <div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
+                        },
+                        {
+                          "name": "CurrentOpportunitiesSegmentClientOptions__Name",
+                          "value": "DFC.App.JobProfile.CurrentOpportunities"
+                        },
+                        {
+                          "name": "CareerPathSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "CareerPathSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlCareerpathApp')]"
+                        },
+                        {
+                          "name": "CareerPathSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "CareerPathSegmentClientOptions__OfflineHtml",
+                          "value": "<section id=\"CareerPathAndProgression\"> <h2 class=\"job-profile-heading\">Career path and progression</h2> <div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
+                        },
+                        {
+                          "name": "CareerPathSegmentClientOptions__Name",
+                          "value": "DFC.App.CareerPath"
+                        },
+                        {
+                          "name": "HowToBecomeSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "HowToBecomeSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlJobprofileHowtobecomeApp')]"
+                        },
+                        {
+                          "name": "HowToBecomeSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "HowToBecomeSegmentClientOptions__OfflineHtml",
+                          "value": ""
+                        },
+                        {
+                          "name": "HowToBecomeSegmentClientOptions__Name",
+                          "value": "DFC.App.JobProfiles.HowToBecome"
+                        },
+                        {
+                          "name": "RelatedCareersSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "RelatedCareersSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlRelatedcareersApp')]"
+                        },
+                        {
+                          "name": "RelatedCareersSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "RelatedCareersSegmentClientOptions__OfflineHtml",
+                          "value": "<div class=\"job-profile-related\"> <h3 class=\"govuk-heading-m\">Related careers</h3><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></div>"
+                        },
+                        {
+                          "name": "RelatedCareersSegmentClientOptions__Name",
+                          "value": "DFC.App.RelatedCareers"
+                        },
+                        {
+                          "name": "WhatItTakesSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "WhatItTakesSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlJobprofileSkillsApp')]"
+                        },
+                        {
+                          "name": "WhatItTakesSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "WhatItTakesSegmentClientOptions__OfflineHtml",
+                          "value": ""
+                        },
+                        {
+                          "name": "WhatItTakesSegmentClientOptions__Name",
+                          "value": "DFC.App.JobProfileSkills"
+                        },
+                        {
+                          "name": "WhatYouWillDoSegmentClientOptions__Timeout",
+                          "value": "00:00:10"
+                        },
+                        {
+                          "name": "WhatYouWillDoSegmentClientOptions__BaseAddress",
+                          "value": "[variables('urlJobprofileTasksApp')]"
+                        },
+                        {
+                          "name": "WhatYouWillDoSegmentClientOptions__Endpoint",
+                          "value": "segment/{0}/contents"
+                        },
+                        {
+                          "name": "WhatYouWillDoSegmentClientOptions__OfflineHtml",
+                          "value": "<section id=\"WhatYouWillDo\"><h2 class=\"job-profile-heading\">What you'll do</h2><div class=\"govuk-inset-text\">The information in this section is currently unavailable. Try again later.</div></section>"
+                        },
+                        {
+                          "name": "WhatYouWillDoSegmentClientOptions__Name",
+                          "value": "DFC.App.JobProfileTasks"
+                        },
+                        {
+                          "name": "FeedbackLinks__SmartSurveyJP",
+                          "value": "[parameters('surveyUrl')]"
+                        },
+                        {
+                          "name": "Logging__ApplicationInsights__LogLevel__Default",
+                          "value": "Information"
+                        }
+                      ]
                     }
                 }
             },

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -37,6 +37,9 @@
         },
         "surveyUrl": {
             "value": "https://some.survey.site/link/to/survey"
+        },
+        "enableAlerts": {
+            "value": false
         }
     }
 }

--- a/Resources/AzureDevops/azure-pipelines.yml
+++ b/Resources/AzureDevops/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-    ArmTemplateRoot: '$(Build.SourcesDirectory)\Resources\ArmTemplates'     
+    ArmTemplateRoot: '$(Build.SourcesDirectory)\Resources\ArmTemplates'
     SolutionBaseName: 'DFC.App.JobProfile'
     BuildPlatform: 'any cpu'
     BuildConfiguration: 'release'
@@ -10,41 +10,54 @@ resources:
   - repository: dfc-devops
     type: github
     name: SkillsFundingAgency/dfc-devops
-    ref: refs/tags/v1.6.12
+    ref: refs/tags/v1.11.2
     endpoint: 'GitHub (ESFA)'
 
-jobs:
-
-#Build and test resources
-- template: AzureDevOpsTemplates/Build/dfc-arm-build.yml@dfc-devops
-  parameters:
-    ArmTemplateRoot: $(ArmTemplateRoot)
-
-#Build and test application
-- job: BuildDotNetCore
-  displayName: Build-DotNetCore
-  pool:
-    name: NCS - CI and CD
-    demands:
+pool:
+  name: NCS - CI and CD
+  demands:
     - msbuild
     - visualstudio
 
-  steps:
-  # Build DFC.App.JobProfile
-  - template: AzureDevOpsTemplates/Build/dfc-dotnetcore-build-sonar.yml@dfc-devops
-    parameters:
-      SolutionBaseName: $(SolutionBaseName)
-      BuildPlatform: $(BuildPlatform)
-      BuildConfiguration: $(BuildConfiguration)
-      DotNetCoreVersion: 2.2.402
-      PublishWebApp: true
-      TestSuffix: UnitTests
+stages:
+  - stage: Build
+    displayName: Build, Test and Analyze
+    jobs:
+    - job: TestArmTemplates
+      displayName: "Test & package ARM template(s)"
+      steps:
+        - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-arm-build.yml@dfc-devops
+          parameters:
+            ArmTemplateRoot: '${{ variables.ArmTemplateRoot }}'
+            SolutionBaseName: '${{ variables.SolutionBaseName }}'
 
-  # Build DFC.App.JobProfile.MessageFunctionApp
-  - template: AzureDevOpsTemplates/Build/dfc-dotnetcore-build-notests.yml@dfc-devops
-    parameters:
-      SolutionBaseName: $(SolutionBaseName).MessageFunctionApp
-      BuildPlatform: $(BuildPlatform)
-      BuildConfiguration: $(BuildConfiguration)
-      DotNetCoreVersion: 2.2.402
-      PublishWebApp: true
+        - task: PublishPipelineArtifact@0
+          displayName: Publish Page Registration artifact
+          inputs:
+            targetPath: '$(Build.SourcesDirectory)/Resources/PageRegistration'
+            artifactName: ${{ variables.SolutionBaseName }}.PageRegistrations
+
+    #Build and test application
+    - job: BuildDotNetCore
+      displayName: Build-DotNetCore
+
+
+      steps:
+      # Build DFC.App.JobProfile
+      - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-sonar.yml@dfc-devops
+        parameters:
+          SolutionBaseName: $(SolutionBaseName)
+          BuildPlatform: $(BuildPlatform)
+          BuildConfiguration: $(BuildConfiguration)
+          DotNetCoreVersion: 3.1.101
+          PublishWebApp: true
+          TestSuffix: UnitTests
+
+      # Build DFC.App.JobProfile.MessageFunctionApp
+      - template:  AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-notests.yml@dfc-devops
+        parameters:
+          SolutionBaseName: $(SolutionBaseName).MessageFunctionApp
+          BuildPlatform: $(BuildPlatform)
+          BuildConfiguration: $(BuildConfiguration)
+          DotNetCoreVersion: 3.1.101
+          PublishWebApp: true

--- a/Resources/PageRegistration/registration.json
+++ b/Resources/PageRegistration/registration.json
@@ -1,10 +1,10 @@
 [
-	{	
+	{
 		"Path": "job-profiles",
 		"TopNavigationText": "Explore careers",
 		"TopNavigationOrder": 400,
 		"Layout": 1,
-		"OfflineHtml": "<div class=\"govuk-width-container\"><H2>Job Profile Service Unavailable</H2></div>",
+		"OfflineHtml": "<div class=\"govuk-width-container\"><div class=\"content-container\"><h1 class=\"heading-xlarge\">Sorry, there is a problem with this service</h1><p>Please try again later.</p><p><a href=\"/contact-us\">Contact us</a> if you want to speak to one of our careers advisers.</p></div></div>",
 		"PhaseBannerHtml": "<div class=\"govuk-phase-banner\"><p class=\"govuk-phase-banner__content\"><strong class=\"govuk-tag govuk-phase-banner__content__tag \">beta</strong> <span class=\"govuk-phase-banner__text\">Complete <a target=\"_blank\" class=\"govuk-link\" href=\"https://surveys.ipsosinteractive.com/mrIWeb/mrIWeb.dll?I.Project=S1039833&amp;id=&amp;cf=ovl \">Ipsos MORI survey</a> to give us your feedback about the service.</span> </p></div>",
 		"SitemapUrl": "https://__AppServiceName__.__appServiceDomain__/sitemap.xml",
 		"RobotsUrl": "https://__AppServiceName__.__appServiceDomain__/robots.txt",
@@ -12,22 +12,22 @@
 			{
 				"PageRegion": 1,
 				"RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/profile/{0}/htmlhead",
-				"HealthCheckRequired": false,
-				"IsHealthy" : true
+				"HealthCheckRequired": true,
+				"IsHealthy": true
 			},
 			{
 				"PageRegion": 4,
 				"RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/profile/{0}/contents",
 				"OfflineHtml": "<div class=\"govuk-width-container\"><H3>Service Unavailable</H3></div>",
-				"HealthCheckRequired": false,
-				"IsHealthy" : true
+				"HealthCheckRequired": true,
+				"IsHealthy": true
 			},
 			{
 				"PageRegion": 8,
 				"RegionEndpoint": "https://__AppServiceName__.__appServiceDomain__/profile/{0}/hero",
 				"OfflineHtml": "<div class=\"govuk-width-container\"><H3>Service Unavailable</H3></div>",
-				"HealthCheckRequired": false,
-				"IsHealthy" : true
+				"HealthCheckRequired": true,
+				"IsHealthy": true
 			}
 		]
 	}


### PR DESCRIPTION
### This release contains the following changes
- DFC-13039-Fixed issue related to search box in jobprofiles (#119)
- DFC 13073 fix redirection vulnerability (#118)
- DFC 13029 add service status for cui (#116)
- DFC-12559 Updated HTML markup for 500 error message page (#115)
- Reverted back token parameters (#114)
- Fix for phase banner (#113)
- NCSD-3224: Updates template to use 'only update staging appsettings' …(#112)
- Fix for publish for new JP causing unhandled exception on patch (#111)
- Return 412 when precondition failed due to concurrent segment app upd… (#110)
- Function version from 2 to 3 (#109)
- Upgrade changes from .net core 2.2 to .net core 3.1 (#108)
- Update the Document view with section elements (#107)
- NCSD-3034: Adds alerting for web and function app (#106)
- NCSD-3033: Removes topic and authrule creation (#105)
- Empty content on error (#104)
- Re-enable healthchecks for job profiles (#103)
- Use offline markup from appsettings rather than hardcoded string (#102)
- Updated Document and Index views for automation tests (#101)
- NCSD-2907: Adds page registrations as a pipeline artifact (#100)
- NCSD-2907: Adds blue/green deployment for web app (#99)
- Handle missing critical segment section with 500 exception (#98)
- Direct to 500 for critical segments being absent (#97)