### PR TITLE
Ad 168215 - Add ID's to Accordion Components

### DIFF
--- a/DFC.App.JobProfile/ViewModels/AccordionSectionViewModel.cs
+++ b/DFC.App.JobProfile/ViewModels/AccordionSectionViewModel.cs
@@ -10,6 +10,8 @@ namespace DFC.App.JobProfile.ViewModels
 
         public string Title { get; set; }
 
+        public string AccordionClass2 { get; set; }
+
         public string Summary { get; set; }
 
         public HtmlString Content { get; set; }

--- a/DFC.App.JobProfile/ViewModels/AccordionSectionViewModel.cs
+++ b/DFC.App.JobProfile/ViewModels/AccordionSectionViewModel.cs
@@ -6,11 +6,9 @@ namespace DFC.App.JobProfile.ViewModels
     [ExcludeFromCodeCoverage]
     public class AccordionSectionViewModel
     {
-        public int SequenceNo { get; set; }
-
         public string Title { get; set; }
 
-        public string AccordionClass2 { get; set; }
+        public string HtmlId { get; set; }
 
         public string Summary { get; set; }
 

--- a/DFC.App.JobProfile/Views/Profile/_CareerPathSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_CareerPathSegment.cshtml
@@ -3,9 +3,8 @@
 @{
     var accordionSectionViewModel = new AccordionSectionViewModel
     {
-        SequenceNo = 4,
         Title = "Career path and progression",
-        AccordionClass2 = "Career_Path_And_Progression-Accordion",
+        HtmlId = "career-path-and-progression",
         Summary = "Look at progression in this role and similar opportunities.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_CareerPathSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_CareerPathSegment.cshtml
@@ -5,6 +5,7 @@
     {
         SequenceNo = 4,
         Title = "Career path and progression",
+        AccordionClass2 = "Career_Path_And_Progression-Accordion",
         Summary = "Look at progression in this role and similar opportunities.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_CurrentOpportunitiesSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_CurrentOpportunitiesSegment.cshtml
@@ -5,6 +5,7 @@
     {
         SequenceNo = 5,
         Title = "Current opportunities",
+        AccordionClass2 = "Current_Opportunities-Accordion",
         Summary = "Find apprenticeships, courses and jobs available near you.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_CurrentOpportunitiesSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_CurrentOpportunitiesSegment.cshtml
@@ -3,9 +3,8 @@
 @{
     var accordionSectionViewModel = new AccordionSectionViewModel
     {
-        SequenceNo = 5,
         Title = "Current opportunities",
-        AccordionClass2 = "Current_Opportunities-Accordion",
+        HtmlId = "current-opportunities",
         Summary = "Find apprenticeships, courses and jobs available near you.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_HowToBecomeSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_HowToBecomeSegment.cshtml
@@ -5,6 +5,7 @@
     {
         SequenceNo = 1,
         Title = "How to become",
+        AccordionClass2 = "How_To_Become-Accordion",
         Summary = "Explore the different ways to get into this role.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_HowToBecomeSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_HowToBecomeSegment.cshtml
@@ -3,9 +3,8 @@
 @{
     var accordionSectionViewModel = new AccordionSectionViewModel
     {
-        SequenceNo = 1,
         Title = "How to become",
-        AccordionClass2 = "How_To_Become-Accordion",
+        HtmlId = "how-to-become",
         Summary = "Explore the different ways to get into this role.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
@@ -5,7 +5,7 @@
     <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="job-profile-accordion-with-summary-sections-heading-@Model.SequenceNo">
+                <span class="govuk-accordion__section-button @Model.AccordionClass2" id="job-profile-accordion-with-summary-sections-heading-@Model.SequenceNo">
                     @Html.Raw(Model.Title)
                 </span>
             </h2>

--- a/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
@@ -9,7 +9,7 @@
                     @Html.Raw(Model.Title)
                 </span>
             </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="jp-accordion-with-summary-sections-summary-@Model.HtmlId">
+            <div class="govuk-accordion__section-summary govuk-body" id="jp-accordion__section-summary-@Model.HtmlId">
                 @Html.Raw(Model.Summary)
             </div>
         </div>

--- a/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
@@ -5,15 +5,15 @@
     <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button @Model.AccordionClass2" id="job-profile-accordion-with-summary-sections-heading-@Model.SequenceNo">
+                <span class="govuk-accordion__section-button" id="job-profile-accordion-@Model.HtmlId">
                     @Html.Raw(Model.Title)
                 </span>
             </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="job-profile-accordion-with-summary-sections-summary-@Model.SequenceNo">
+            <div class="govuk-accordion__section-summary govuk-body" id="job-profile-accordion-with-summary-sections-summary-@Model.HtmlId">
                 @Html.Raw(Model.Summary)
             </div>
         </div>
-        <div id="job-profile-accordion-with-summary-sections-content-@Model.SequenceNo" class="govuk-accordion__section-content" aria-labelledby="job-profile-accordion-with-summary-sections-heading-@Model.SequenceNo">
+        <div id="job-profile-accordion-with-summary-sections-content-@Model.HtmlId" class="govuk-accordion__section-content" aria-labelledby="job-profile-accordion-with-summary-sections-heading-@Model.HtmlId">
             @Html.Raw(Model.Content)
         </div>
     </div>

--- a/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_JobProfileAccordionSection.cshtml
@@ -5,15 +5,15 @@
     <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="job-profile-accordion-@Model.HtmlId">
+                <span class="govuk-accordion__section-button" id="jp-accordion-@Model.HtmlId">
                     @Html.Raw(Model.Title)
                 </span>
             </h2>
-            <div class="govuk-accordion__section-summary govuk-body" id="job-profile-accordion-with-summary-sections-summary-@Model.HtmlId">
+            <div class="govuk-accordion__section-summary govuk-body" id="jp-accordion-with-summary-sections-summary-@Model.HtmlId">
                 @Html.Raw(Model.Summary)
             </div>
         </div>
-        <div id="job-profile-accordion-with-summary-sections-content-@Model.HtmlId" class="govuk-accordion__section-content" aria-labelledby="job-profile-accordion-with-summary-sections-heading-@Model.HtmlId">
+        <div id="job-profile-accordion-with-summary-sections-content-@Model.HtmlId" class="govuk-accordion__section-content" aria-labelledby="jp-accordion-with-summary-sections-heading-@Model.HtmlId">
             @Html.Raw(Model.Content)
         </div>
     </div>

--- a/DFC.App.JobProfile/Views/Profile/_WhatItTakesSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_WhatItTakesSegment.cshtml
@@ -5,6 +5,7 @@
     {
         SequenceNo = 2,
         Title = "What it takes",
+        AccordionClass2 = "What_It_Takes-Accordion",
         Summary = "Find out what skills you&rsquo;ll use in this role.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_WhatItTakesSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_WhatItTakesSegment.cshtml
@@ -3,9 +3,8 @@
 @{
     var accordionSectionViewModel = new AccordionSectionViewModel
     {
-        SequenceNo = 2,
         Title = "What it takes",
-        AccordionClass2 = "What_It_Takes-Accordion",
+        HtmlId = "what-it-takes",
         Summary = "Find out what skills you&rsquo;ll use in this role.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_WhatYouWillDoSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_WhatYouWillDoSegment.cshtml
@@ -5,6 +5,7 @@
     {
         SequenceNo = 3,
         Title = "What you&rsquo;ll do",
+        AccordionClass2 = "What_Youll_Do-Accordion",
         Summary = "Discover the day to day tasks you&rsquo;ll do in this role.",
         Content = Model,
     };

--- a/DFC.App.JobProfile/Views/Profile/_WhatYouWillDoSegment.cshtml
+++ b/DFC.App.JobProfile/Views/Profile/_WhatYouWillDoSegment.cshtml
@@ -3,9 +3,8 @@
 @{
     var accordionSectionViewModel = new AccordionSectionViewModel
     {
-        SequenceNo = 3,
         Title = "What you&rsquo;ll do",
-        AccordionClass2 = "What_Youll_Do-Accordion",
+        HtmlId = "what-youll-do",
         Summary = "Discover the day to day tasks you&rsquo;ll do in this role.",
         Content = Model,
     };


### PR DESCRIPTION
Related to [AD-168215](https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_workitems/edit/168215)

The PR introduces a custome ID to load to the Accordion components.
The components load to a view that dynamicly loads the component based on the model that has been selected. HTML ID is a new value used for these ID's.

ID's will render out as follows
- jp-accordion-how-to-become
- jp-accordion-career-path-and-progression
- jp-accordion-current-opportunities
- jp-accordion-what-it-takes
- jp-accordion-what-youll-do